### PR TITLE
Changes from background agent bc-05aadce0-34c2-499b-bfb7-a3bd5ce67221

### DIFF
--- a/AISnake.lua
+++ b/AISnake.lua
@@ -1824,11 +1824,16 @@ function AISnake.new(startPosition, preservedPersonalityType)
 	task.defer(function()
 		-- Wait for model to be ready
 		task.wait(0.1)
+		
+		-- Check if snake was destroyed during wait
+		if self._destroyed or not self.Segments then
+			return
+		end
 
 		-- Gradually move forward to create proper segment spacing
 		for step = 1, 20 do
 			-- Check if snake is still alive
-			if not self.RootPart or not self.RootPart.Parent then
+			if not self.RootPart or not self.RootPart.Parent or self._destroyed then
 				break
 			end
 
@@ -1878,20 +1883,22 @@ function AISnake.new(startPosition, preservedPersonalityType)
 		self:updateBrain()
 
 		-- Fade in segments
-		for i, segment in ipairs(self.Segments) do
-			if segment and segment.Parent then
-				task.spawn(function()
-					local fadeSteps = 10
-					for step = 1, fadeSteps do
-						if segment and segment.Parent then
-							segment.Transparency = 1 - (step / fadeSteps)
+		if self.Segments then
+			for i, segment in ipairs(self.Segments) do
+				if segment and segment.Parent then
+					task.spawn(function()
+						local fadeSteps = 10
+						for step = 1, fadeSteps do
+							if segment and segment.Parent then
+								segment.Transparency = 1 - (step / fadeSteps)
+							end
+							task.wait(0.02)
 						end
-						task.wait(0.02)
-					end
-					if segment and segment.Parent then
-						segment.Transparency = 0
-					end
-				end)
+						if segment and segment.Parent then
+							segment.Transparency = 0
+						end
+					end)
+				end
 			end
 		end
 	end)

--- a/AISnake.lua
+++ b/AISnake.lua
@@ -1827,6 +1827,11 @@ function AISnake.new(startPosition, preservedPersonalityType)
 
 		-- Gradually move forward to create proper segment spacing
 		for step = 1, 20 do
+			-- Check if snake is still alive
+			if not self.RootPart or not self.RootPart.Parent then
+				break
+			end
+
 			-- Move forward slightly
 			local moveDistance = self.SegmentSpacing * 0.1
 			local newPos = self.Position + self.Direction * moveDistance
@@ -2467,11 +2472,15 @@ function AISnake:updateMovement(dt)
 		self.Position = newPosition
 	end
 
-	self.RootPart.Position = self.Position
+	if self.RootPart then
+		self.RootPart.Position = self.Position
+	end
 
 	local headOffset = self.Direction * 1.5
 	local newHeadPos = self.Position + headOffset
-	self.HeadParts.head.CFrame = CFramelookAt(newHeadPos, newHeadPos + self.Direction)
+	if self.HeadParts and self.HeadParts.head then
+		self.HeadParts.head.CFrame = CFramelookAt(newHeadPos, newHeadPos + self.Direction)
+	end
 
 	-- Update eyes position (match OptimizedSnakeSystem)
 	if self.HeadParts.leftEye and self.HeadParts.rightEye then

--- a/ServerScriptService/MainServer.server.lua
+++ b/ServerScriptService/MainServer.server.lua
@@ -160,6 +160,12 @@ local function onPlayerAdded(player)
     -- Check periodically for snake creation
     local checkConnection
     checkConnection = RunService.Heartbeat:Connect(function()
+        -- Safety check in case controller was destroyed
+        if not controller or not playerControllers[player] then
+            checkConnection:Disconnect()
+            return
+        end
+        
         if controller.snakeObject or controller.isDestroyed then
             checkConnection:Disconnect()
             return
@@ -241,6 +247,9 @@ local function onPlayerAdded(player)
         -- Set up death handler for orb spawning
         local humanoid = character:WaitForChild("Humanoid")
         humanoid.Died:Connect(function()
+            -- Safety check in case player left
+            if not player.Parent then return end
+            
             -- Get snake length for orb calculation
             local snakeLength = 55 -- default
             if player:FindFirstChild("leaderstats") then
@@ -267,7 +276,7 @@ local function onPlayerAdded(player)
         -- Also set up monitoring for snake creation
         local checkCount = 0
         task.spawn(function()
-            while not currentController.snakeObject and checkCount < 10 do
+            while currentController and not currentController.snakeObject and checkCount < 10 do
                 task.wait(0.5)
                 checkForSnake()
                 checkCount = checkCount + 1

--- a/ServerScriptService/RemoteEventsSetup.server.lua
+++ b/ServerScriptService/RemoteEventsSetup.server.lua
@@ -23,7 +23,9 @@ local remoteEvents = {
     "SetSpectatorCamera",     -- For spectator camera control
     "RespawnSnake",          -- For respawning player
     "PlayerRevivedEffect",   -- For revive VFX
-    "PlayerDeathEffect"      -- For death VFX
+    "PlayerDeathEffect",     -- For death VFX
+    "StopSnakeMovement",     -- For stopping client-side snake control
+    "ResumeSnakeMovement"    -- For resuming snake movement after revive
 }
 
 -- Create each RemoteEvent if it doesn't exist

--- a/ServerScriptService/RemoteEventsSetup.server.lua
+++ b/ServerScriptService/RemoteEventsSetup.server.lua
@@ -1,0 +1,39 @@
+--[[
+    RemoteEventsSetup - Creates necessary RemoteEvents for the game systems
+    This script should run before other systems to ensure RemoteEvents exist
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+-- Add a small delay to ensure ReplicatedStorage is ready
+RunService.Heartbeat:Wait()
+
+-- Create Remotes folder if it doesn't exist
+local remotes = ReplicatedStorage:FindFirstChild("Remotes")
+if not remotes then
+    remotes = Instance.new("Folder")
+    remotes.Name = "Remotes"
+    remotes.Parent = ReplicatedStorage
+end
+
+-- List of RemoteEvents to create
+local remoteEvents = {
+    "ShowDeathScreen",        -- For showing death menu
+    "SetSpectatorCamera",     -- For spectator camera control
+    "RespawnSnake",          -- For respawning player
+    "PlayerRevivedEffect",   -- For revive VFX
+    "PlayerDeathEffect"      -- For death VFX
+}
+
+-- Create each RemoteEvent if it doesn't exist
+for _, eventName in ipairs(remoteEvents) do
+    if not remotes:FindFirstChild(eventName) then
+        local remoteEvent = Instance.new("RemoteEvent")
+        remoteEvent.Name = eventName
+        remoteEvent.Parent = remotes
+        print("Created RemoteEvent:", eventName)
+    end
+end
+
+print("RemoteEvents setup complete")

--- a/ServerStorage/ServerModules/CollisionModule.module.lua
+++ b/ServerStorage/ServerModules/CollisionModule.module.lua
@@ -35,12 +35,10 @@ function CollisionModule.new(playerControllers)
     self.lastCacheUpdate = 0
     self.CACHE_UPDATE_INTERVAL = 1 -- Update cache every second
     
-    warn("[CollisionModule] Created new collision module")
     return self
 end
 
 function CollisionModule:start()
-    warn("[CollisionModule] Starting collision detection system")
     -- Connect to heartbeat for collision checks
     self.collisionConnection = RunService.Heartbeat:Connect(function(dt)
         self:update(dt)
@@ -81,11 +79,6 @@ function CollisionModule:update(dt)
         local currentState = controller.fsm:getCurrentState()
         local canCollide = controller:canCollide()
         
-        -- Debug: Log state info periodically
-        if self.frameCount % 120 == 0 then  -- Every 4 seconds
-            warn("[CollisionModule] Player:", player.Name, "State:", currentState, "CanCollide:", canCollide)
-        end
-        
         if currentState == "Alive" and canCollide then
             self:_checkPlayerCollisions(controller)
             checksThisFrame = checksThisFrame + 1
@@ -96,13 +89,7 @@ end
 function CollisionModule:_checkPlayerCollisions(controller)
     local head = controller:getSnakeHead()
     if not head then 
-        warn("[CollisionModule] No head found for", controller.player.Name)
         return 
-    end
-    
-    -- Debug: Log that we're checking collisions
-    if self.frameCount % 60 == 0 then  -- Log every 2 seconds
-        warn("[CollisionModule] Checking collisions for", controller.player.Name, "- Found", #self.snakeCache, "snakes in cache")
     end
     
     -- Check for orb collection
@@ -140,11 +127,6 @@ function CollisionModule:_checkFatalCollisions(controller, head)
         if snakeData.Head then
             local distance = (snakeData.Head.Position - head.Position).Magnitude
             
-            -- Debug: Log close encounters
-            if distance <= COLLISION_CONFIG.HEAD_RADIUS * 2 then
-                warn("[CollisionModule] CLOSE ENCOUNTER:", controller.player.Name, "distance", distance, "to", snakeData.IsAI and "AI Snake" or (snakeData.Player and snakeData.Player.Name or "Unknown"))
-            end
-            
             if distance <= COLLISION_CONFIG.HEAD_RADIUS then
                 local collisionData = {
                     isFatal = true,
@@ -156,7 +138,6 @@ function CollisionModule:_checkFatalCollisions(controller, head)
                     isAI = snakeData.IsAI
                 }
                 
-                warn("[CollisionModule] HEAD COLLISION DETECTED between", controller.player.Name, "and", snakeData.IsAI and "AI Snake" or snakeData.Player.Name)
                 controller.events.onFatalHit:Fire(collisionData)
                 return
             end
@@ -182,7 +163,6 @@ function CollisionModule:_checkFatalCollisions(controller, head)
                             isAI = snakeData.IsAI
                         }
                         
-                        warn("[CollisionModule] BODY COLLISION DETECTED between", controller.player.Name, "and", snakeData.IsAI and "AI Snake" or (snakeData.Player and snakeData.Player.Name or "Unknown"))
                         controller.events.onFatalHit:Fire(collisionData)
                         return
                     end
@@ -202,7 +182,6 @@ function CollisionModule:_checkFatalCollisions(controller, head)
                 isWallCollision = true
             }
             
-            warn("[CollisionModule] WALL COLLISION DETECTED for", controller.player.Name)
             controller.events.onFatalHit:Fire(collisionData)
             return
         end
@@ -269,8 +248,6 @@ function CollisionModule:_updateCaches()
                     end
                 end
                 
-                warn("[CollisionModule] Found player snake:", snakeModel.Name, "with", #segments, "segments for", player.Name)
-                
                 table.insert(self.snakeCache, {
                     Head = head,
                     Model = snakeModel,
@@ -278,13 +255,6 @@ function CollisionModule:_updateCaches()
                     IsAI = false,
                     Player = player
                 })
-            else
-                warn("[CollisionModule] No head found for player snake:", player.Name)
-            end
-        else
-            -- Debug: Log why snake wasn't found
-            if not snakeModel then
-                warn("[CollisionModule] No snake model found for player:", player.Name)
             end
         end
     end
@@ -315,8 +285,6 @@ function CollisionModule:_updateCaches()
                 -- Also check if it's tagged as AISnake
                 local isAI = CollectionService:HasTag(child, "AISnake")
                 
-                warn("[CollisionModule] Found AI snake:", child.Name, "with", #segments, "segments")
-                
                 table.insert(self.snakeCache, {
                     Head = head,
                     Model = child,
@@ -327,8 +295,6 @@ function CollisionModule:_updateCaches()
             end
         end
     end
-    
-    warn("[CollisionModule] Cache updated - Orbs:", #self.orbCache, "Obstacles:", #self.obstacleCache, "Snakes:", #self.snakeCache)
 end
 
 -- Helper to get player from part

--- a/ServerStorage/ServerModules/CollisionModule.module.lua
+++ b/ServerStorage/ServerModules/CollisionModule.module.lua
@@ -17,7 +17,7 @@ local COLLISION_CONFIG = {
     BODY_DISTANCE = 4,    -- Increased from 2.8 for better detection
     ORB_COLLECTION_RADIUS = 6,
     SELF_COLLISION_IGNORE_SEGMENTS = 10,
-    FRAME_SKIP = 2, -- Check collisions more frequently (was 3)
+    FRAME_SKIP = 1, -- Check every frame for immediate response
     MAX_CHECKS_PER_FRAME = 50
 }
 

--- a/ServerStorage/ServerModules/CollisionModule.module.lua
+++ b/ServerStorage/ServerModules/CollisionModule.module.lua
@@ -13,11 +13,11 @@ CollisionModule.__index = CollisionModule
 
 -- Constants for collision detection
 local COLLISION_CONFIG = {
-    HEAD_RADIUS = 3.5,
-    BODY_DISTANCE = 2.8,
-    ORB_COLLECTION_RADIUS = 5,
+    HEAD_RADIUS = 5,      -- Increased from 3.5 for better detection
+    BODY_DISTANCE = 4,    -- Increased from 2.8 for better detection
+    ORB_COLLECTION_RADIUS = 6,
     SELF_COLLISION_IGNORE_SEGMENTS = 10,
-    FRAME_SKIP = 3, -- Check collisions every N frames for performance
+    FRAME_SKIP = 2, -- Check collisions more frequently (was 3)
     MAX_CHECKS_PER_FRAME = 50
 }
 
@@ -81,6 +81,11 @@ function CollisionModule:update(dt)
         local currentState = controller.fsm:getCurrentState()
         local canCollide = controller:canCollide()
         
+        -- Debug: Log state info periodically
+        if self.frameCount % 120 == 0 then  -- Every 4 seconds
+            warn("[CollisionModule] Player:", player.Name, "State:", currentState, "CanCollide:", canCollide)
+        end
+        
         if currentState == "Alive" and canCollide then
             self:_checkPlayerCollisions(controller)
             checksThisFrame = checksThisFrame + 1
@@ -93,6 +98,11 @@ function CollisionModule:_checkPlayerCollisions(controller)
     if not head then 
         warn("[CollisionModule] No head found for", controller.player.Name)
         return 
+    end
+    
+    -- Debug: Log that we're checking collisions
+    if self.frameCount % 60 == 0 then  -- Log every 2 seconds
+        warn("[CollisionModule] Checking collisions for", controller.player.Name, "- Found", #self.snakeCache, "snakes in cache")
     end
     
     -- Check for orb collection
@@ -127,20 +137,29 @@ function CollisionModule:_checkFatalCollisions(controller, head)
         end
         
         -- Check head-to-head collision
-        if snakeData.Head and (snakeData.Head.Position - head.Position).Magnitude <= COLLISION_CONFIG.HEAD_RADIUS then
-            local collisionData = {
-                isFatal = true,
-                hitPart = snakeData.Head,
-                hitPosition = head.Position,
-                preventOrbs = false,
-                isHeadCollision = true,
-                killerPlayer = snakeData.Player,
-                isAI = snakeData.IsAI
-            }
+        if snakeData.Head then
+            local distance = (snakeData.Head.Position - head.Position).Magnitude
             
-            warn("[CollisionModule] HEAD COLLISION DETECTED between", controller.player.Name, "and", snakeData.IsAI and "AI Snake" or snakeData.Player.Name)
-            controller.events.onFatalHit:Fire(collisionData)
-            return
+            -- Debug: Log close encounters
+            if distance <= COLLISION_CONFIG.HEAD_RADIUS * 2 then
+                warn("[CollisionModule] CLOSE ENCOUNTER:", controller.player.Name, "distance", distance, "to", snakeData.IsAI and "AI Snake" or (snakeData.Player and snakeData.Player.Name or "Unknown"))
+            end
+            
+            if distance <= COLLISION_CONFIG.HEAD_RADIUS then
+                local collisionData = {
+                    isFatal = true,
+                    hitPart = snakeData.Head,
+                    hitPosition = head.Position,
+                    preventOrbs = false,
+                    isHeadCollision = true,
+                    killerPlayer = snakeData.Player,
+                    isAI = snakeData.IsAI
+                }
+                
+                warn("[CollisionModule] HEAD COLLISION DETECTED between", controller.player.Name, "and", snakeData.IsAI and "AI Snake" or snakeData.Player.Name)
+                controller.events.onFatalHit:Fire(collisionData)
+                return
+            end
         end
         
         -- Check collision with snake body segments
@@ -259,6 +278,13 @@ function CollisionModule:_updateCaches()
                     IsAI = false,
                     Player = player
                 })
+            else
+                warn("[CollisionModule] No head found for player snake:", player.Name)
+            end
+        else
+            -- Debug: Log why snake wasn't found
+            if not snakeModel then
+                warn("[CollisionModule] No snake model found for player:", player.Name)
             end
         end
     end
@@ -269,24 +295,27 @@ function CollisionModule:_updateCaches()
             -- This is an AI snake
             local head = child:FindFirstChild("Segment0_Head")
             if head and head:IsA("BasePart") then
-                -- AI snakes have segments named "AISegment1", "AISegment2", etc.
                 local segments = {}
                 
-                -- First add the head as segment 0
+                -- First add the head
                 table.insert(segments, head)
                 
-                -- Then find all body segments
-                for _, part in pairs(child:GetChildren()) do
-                    if part:IsA("BasePart") and part.Name:match("^AISegment%d+") then
-                        local segmentNumber = tonumber(part.Name:match("AISegment(%d+)"))
-                        if segmentNumber then
-                            segments[segmentNumber + 1] = part -- +1 because head is at index 1
-                        end
+                -- AI snakes use the same naming as player snakes now: Segment1, Segment2, etc.
+                local i = 1
+                while true do
+                    local segment = child:FindFirstChild("Segment" .. i) or child:FindFirstChild("AISegment" .. i)
+                    if segment and segment:IsA("BasePart") then
+                        table.insert(segments, segment)
+                        i = i + 1
+                    else
+                        break
                     end
                 end
                 
                 -- Also check if it's tagged as AISnake
                 local isAI = CollectionService:HasTag(child, "AISnake")
+                
+                warn("[CollisionModule] Found AI snake:", child.Name, "with", #segments, "segments")
                 
                 table.insert(self.snakeCache, {
                     Head = head,

--- a/ServerStorage/ServerModules/States/AliveState.module.lua
+++ b/ServerStorage/ServerModules/States/AliveState.module.lua
@@ -3,6 +3,8 @@
     Handles player input processing, movement, and collision response
 ]]
 
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
 local AliveState = {}
 AliveState.__index = AliveState
 
@@ -17,6 +19,26 @@ function AliveState:OnEnter()
     -- Enable player controls
     self.controller.collisionState.canCollide = true
     
+    -- Resume snake movement on client
+    local remotes = ReplicatedStorage:WaitForChild("Remotes")
+    local resumeMovementRemote = remotes:FindFirstChild("ResumeSnakeMovement")
+    if resumeMovementRemote then
+        resumeMovementRemote:FireClient(self.controller.player)
+    end
+    
+    -- Resume server-side snake movement if it was stopped
+    local snakeSystem = _G.PlayerSnakes and _G.PlayerSnakes[self.controller.player]
+    if snakeSystem and not snakeSystem.updateConnection then
+        warn("[AliveState] Resuming server snake movement for", self.controller.player.Name)
+        -- Re-create the update connection
+        local RunService = game:GetService("RunService")
+        snakeSystem.updateConnection = RunService.Heartbeat:Connect(function(deltaTime)
+            if snakeSystem.update then
+                snakeSystem:update(deltaTime)
+            end
+        end)
+    end
+    
     -- Notify systems that player is alive
     self.controller:notifyStateChange("Alive")
     
@@ -25,6 +47,8 @@ function AliveState:OnEnter()
         self.controller.player:SetAttribute("IsDead", false)
         self.controller.player:SetAttribute("IsReviving", false)
     end
+    
+    warn("[AliveState] Successfully entered for", self.controller.player.Name)
 end
 
 function AliveState:OnExecute(dt)

--- a/ServerStorage/ServerModules/States/AliveState.module.lua
+++ b/ServerStorage/ServerModules/States/AliveState.module.lua
@@ -29,7 +29,7 @@ function AliveState:OnEnter()
     -- Resume server-side snake movement if it was stopped
     local snakeSystem = _G.PlayerSnakes and _G.PlayerSnakes[self.controller.player]
     if snakeSystem and not snakeSystem.updateConnection then
-        warn("[AliveState] Resuming server snake movement for", self.controller.player.Name)
+
         -- Re-create the update connection
         local RunService = game:GetService("RunService")
         snakeSystem.updateConnection = RunService.Heartbeat:Connect(function(deltaTime)
@@ -48,7 +48,7 @@ function AliveState:OnEnter()
         self.controller.player:SetAttribute("IsReviving", false)
     end
     
-    warn("[AliveState] Successfully entered for", self.controller.player.Name)
+
 end
 
 function AliveState:OnExecute(dt)

--- a/ServerStorage/ServerModules/States/DyingState.module.lua
+++ b/ServerStorage/ServerModules/States/DyingState.module.lua
@@ -36,10 +36,6 @@ function DyingState:OnEnter(collisionData)
         self.currentLength = 55 -- default
     end
     
-    -- Log the death
-    warn("[DyingState] Player", self.controller.player.Name, "entered dying state")
-    warn("[DyingState] Death position:", self.deathPosition, "Current length:", self.currentLength)
-    
     -- Store character reference for later
     local character = self.controller.player.Character
     local humanoid = character and character:FindFirstChildOfClass("Humanoid")
@@ -62,10 +58,13 @@ function DyingState:OnEnter(collisionData)
             action = "hide"
         })
         
-        -- Wait a moment for death to process
-        task.wait(0.5)
+        -- IMMEDIATE death effect for visual feedback
+        local deathEffectRemote = remotes:FindFirstChild("PlayerDeathEffect")
+        if deathEffectRemote and self.deathPosition then
+            deathEffectRemote:FireAllClients(self.controller.player, self.deathPosition)
+        end
         
-        -- Disable movement but don't kill yet
+        -- Disable movement IMMEDIATELY (no wait)
         if humanoid then
             humanoid.WalkSpeed = 0
             humanoid.JumpPower = 0
@@ -75,35 +74,48 @@ function DyingState:OnEnter(collisionData)
         -- Stop snake movement by disconnecting its update loop
         local snakeSystem = _G.PlayerSnakes and _G.PlayerSnakes[self.controller.player]
         if snakeSystem and snakeSystem.updateConnection then
-            warn("[DyingState] Stopping snake movement for", self.controller.player.Name)
             snakeSystem.updateConnection:Disconnect()
             snakeSystem.updateConnection = nil
         end
         
-        -- Tell client to stop snake movement
+        -- Tell client to stop snake movement IMMEDIATELY
         local stopMovementRemote = remotes:FindFirstChild("StopSnakeMovement")
         if stopMovementRemote then
             stopMovementRemote:FireClient(self.controller.player)
         end
         
-        -- Make snake invisible/non-collidable
+        -- Make snake fade out quickly for polished effect
         if self.controller.snakeObject then
             if self.controller.snakeObject:IsA("Model") then
-                for _, part in ipairs(self.controller.snakeObject:GetDescendants()) do
-                    if part:IsA("BasePart") then
-                        part.CanCollide = false
-                        part.Transparency = 0.5
+                -- Create a quick fade effect
+                task.spawn(function()
+                    local parts = {}
+                    for _, part in ipairs(self.controller.snakeObject:GetDescendants()) do
+                        if part:IsA("BasePart") then
+                            part.CanCollide = false
+                            table.insert(parts, part)
+                        end
                     end
-                end
+                    
+                    -- Quick fade out (0.3 seconds)
+                    local fadeSteps = 6
+                    for i = 1, fadeSteps do
+                        for _, part in ipairs(parts) do
+                            if part and part.Parent then
+                                part.Transparency = i / fadeSteps
+                            end
+                        end
+                        task.wait(0.05)
+                    end
+                end)
             end
         end
         
-        -- Short pause before showing prompt
-        task.wait(0.2)
+        -- Very short pause before showing prompt (reduced from 0.2)
+        task.wait(0.1)
         
         -- Check for revives
         if self.controller:hasReviveToken() then
-            warn("[DyingState] Player has revive tokens available")
             
             -- Get remotes
             local remotes = ReplicatedStorage:WaitForChild("Remotes")
@@ -159,16 +171,13 @@ function DyingState:OnEnter(collisionData)
                                     string.format("%f,%f,%f", self.deathPosition.X, self.deathPosition.Y, self.deathPosition.Z))
                             end
                             
-                            warn("[DyingState] Player chose to revive")
                             -- Do NOT kill the humanoid - they're reviving!
                             resolve("Reviving")
                         else
-                            warn("[DyingState] Player declined revive")
                             self.controller.player:SetAttribute("AwaitingReviveResponse", false)
                             
                             -- Player declined - kill humanoid and show death UI
                             if humanoid and humanoid.Health > 0 then
-                                warn("[DyingState] Killing player humanoid (declined revive)")
                                 humanoid.Health = 0
                             end
                             
@@ -189,13 +198,11 @@ function DyingState:OnEnter(collisionData)
                 timeoutTask = task.delay(10, function()
                     if not responded and responseConnection then
                         responseConnection:Disconnect()
-                        warn("[DyingState] Revive prompt timed out")
                         self.controller.player:SetAttribute("RevivePromptActive", false)
                         self.controller.player:SetAttribute("AwaitingReviveResponse", false)
                         
                         -- Kill humanoid on timeout
                         if humanoid and humanoid.Health > 0 then
-                            warn("[DyingState] Killing player humanoid (timeout)")
                             humanoid.Health = 0
                         end
                         
@@ -229,7 +236,6 @@ function DyingState:OnEnter(collisionData)
                 task.wait(1.0)
                 -- Kill the player since we can't prompt
                 if humanoid and humanoid.Health > 0 then
-                    warn("[DyingState] Killing player humanoid (no prompt remote)")
                     humanoid.Health = 0
                 end
                 task.wait(0.5)
@@ -237,10 +243,9 @@ function DyingState:OnEnter(collisionData)
             end
         else
             -- No revives available, go straight to spectating
-            warn("[DyingState] No revive tokens available")
             
-            -- Wait a bit before showing death UI to prevent jarring transition
-            task.wait(1.0)
+            -- Much shorter wait before showing death UI (reduced from 1.0)
+            task.wait(0.3)
             
             -- Show death UI after delay
             if deathUIRemote then
@@ -251,7 +256,6 @@ function DyingState:OnEnter(collisionData)
             
             -- Kill the player after showing UI
             if humanoid and humanoid.Health > 0 then
-                warn("[DyingState] Killing player humanoid (no revives)")
                 humanoid.Health = 0
             end
             
@@ -323,7 +327,6 @@ function DyingState:_killPlayer()
     if character then
         local humanoid = character:FindFirstChildOfClass("Humanoid")
         if humanoid and humanoid.Health > 0 then
-            warn("[DyingState] Killing player humanoid")
             humanoid.Health = 0
         end
     end

--- a/ServerStorage/ServerModules/States/DyingState.module.lua
+++ b/ServerStorage/ServerModules/States/DyingState.module.lua
@@ -72,6 +72,20 @@ function DyingState:OnEnter(collisionData)
             humanoid.PlatformStand = true
         end
         
+        -- Stop snake movement by disconnecting its update loop
+        local snakeSystem = _G.PlayerSnakes and _G.PlayerSnakes[self.controller.player]
+        if snakeSystem and snakeSystem.updateConnection then
+            warn("[DyingState] Stopping snake movement for", self.controller.player.Name)
+            snakeSystem.updateConnection:Disconnect()
+            snakeSystem.updateConnection = nil
+        end
+        
+        -- Tell client to stop snake movement
+        local stopMovementRemote = remotes:FindFirstChild("StopSnakeMovement")
+        if stopMovementRemote then
+            stopMovementRemote:FireClient(self.controller.player)
+        end
+        
         -- Make snake invisible/non-collidable
         if self.controller.snakeObject then
             if self.controller.snakeObject:IsA("Model") then

--- a/ServerStorage/ServerModules/States/SpectatingState.module.lua
+++ b/ServerStorage/ServerModules/States/SpectatingState.module.lua
@@ -19,7 +19,6 @@ function SpectatingState.new(controller)
 end
 
 function SpectatingState:OnEnter()
-    warn("[SpectatingState] Player", self.controller.player.Name, "entered spectating state")
     
     -- Check if player is somehow in revive process (shouldn't happen but safety check)
     if self.controller.player:GetAttribute("IsReviving") or 
@@ -169,7 +168,6 @@ end
 function SpectatingState:_sendDeathScreenCommand()
     -- Only send death screen once per spectating session
     if self.deathScreenSent then
-        warn("[SpectatingState] Death screen already sent, skipping")
         return
     end
     
@@ -197,7 +195,6 @@ function SpectatingState:_sendDeathScreenCommand()
             timestamp = os.time()
         })
         self.deathScreenSent = true
-        warn("[SpectatingState] Death screen command sent")
     else
         warn("[SpectatingState] ShowDeathScreen remote not found")
     end

--- a/ServerStorage/ServerModules/States/SpectatingState.module.lua
+++ b/ServerStorage/ServerModules/States/SpectatingState.module.lua
@@ -14,24 +14,37 @@ function SpectatingState.new(controller)
     self.controller = controller
     self.name = "Spectating"
     self.spectateIndex = 1
+    self.deathScreenSent = false
     return self
 end
 
 function SpectatingState:OnEnter()
-    -- Set spectating attributes
-    self.controller.player:SetAttribute("IsSpectating", true)
-    self.controller.player:SetAttribute("IsDead", true)
+    warn("[SpectatingState] Player", self.controller.player.Name, "entered spectating state")
     
-    -- Ensure snake is cleaned up
-    if self.controller.snakeObject then
-        if self.controller.snakeObject.destroy then
-            self.controller.snakeObject:destroy()
-        end
-        self.controller.snakeObject = nil
+    -- Check if player is somehow in revive process (shouldn't happen but safety check)
+    if self.controller.player:GetAttribute("IsReviving") or 
+       self.controller.player:GetAttribute("RevivingNow") or 
+       self.controller.player:GetAttribute("JustRevived") then
+        warn("[SpectatingState] WARNING: Player has revive attributes in spectating state, clearing them")
+        self.controller.player:SetAttribute("IsReviving", false)
+        self.controller.player:SetAttribute("RevivingNow", false)
+        self.controller.player:SetAttribute("JustRevived", false)
+        self.controller.player:SetAttribute("RevivePromptActive", false)
+        self.controller.player:SetAttribute("AwaitingReviveResponse", false)
     end
     
-    -- Switch to spectator camera
-    self:_setupSpectatorCamera()
+    -- This state is entered when player is truly dead (no revives or declined)
+    -- Wait a moment to ensure all states are properly set
+    task.wait(0.1)
+    
+    -- Now we tell the client to show the death screen
+    self:_sendDeathScreenCommand()
+    
+    -- Disable controls
+    self.controller.collisionState.canCollide = false
+    
+    -- Make player spectate (implementation depends on your spectating system)
+    self:_enterSpectatorMode()
     
     -- Notify state change
     self.controller:notifyStateChange("Spectating")
@@ -46,8 +59,28 @@ function SpectatingState:OnExit()
     -- Clear spectating attributes
     self.controller.player:SetAttribute("IsSpectating", false)
     
+    -- Reset flags
+    self.deathScreenSent = false
+    
     -- Reset camera to player
     self:_resetCamera()
+end
+
+function SpectatingState:_enterSpectatorMode()
+    -- Set spectating attributes
+    self.controller.player:SetAttribute("IsSpectating", true)
+    self.controller.player:SetAttribute("IsDead", true)
+    
+    -- Ensure snake is cleaned up
+    if self.controller.snakeObject then
+        if self.controller.snakeObject.destroy then
+            self.controller.snakeObject:destroy()
+        end
+        self.controller.snakeObject = nil
+    end
+    
+    -- Switch to spectator camera
+    self:_setupSpectatorCamera()
 end
 
 function SpectatingState:_setupSpectatorCamera()
@@ -129,6 +162,44 @@ function SpectatingState:cycleSpectateTarget(direction)
             mode = "spectate",
             target = alivePlayers[self.spectateIndex]
         })
+    end
+end
+
+-- Send death screen command to client
+function SpectatingState:_sendDeathScreenCommand()
+    -- Only send death screen once per spectating session
+    if self.deathScreenSent then
+        warn("[SpectatingState] Death screen already sent, skipping")
+        return
+    end
+    
+    local remotes = ReplicatedStorage:WaitForChild("Remotes")
+    local showDeathScreenRemote = remotes:FindFirstChild("ShowDeathScreen")
+    
+    if showDeathScreenRemote then
+        -- Gather stats for the death screen
+        local stats = {}
+        local leaderstats = self.controller.player:FindFirstChild("leaderstats")
+        
+        if leaderstats then
+            local length = leaderstats:FindFirstChild("Length")
+            if length then
+                stats.score = length.Value
+            end
+        end
+        
+        -- Get kills from attribute
+        stats.kills = self.controller.player:GetAttribute("LastKills") or 0
+        
+        -- Send the command with stats
+        showDeathScreenRemote:FireClient(self.controller.player, {
+            stats = stats,
+            timestamp = os.time()
+        })
+        self.deathScreenSent = true
+        warn("[SpectatingState] Death screen command sent")
+    else
+        warn("[SpectatingState] ShowDeathScreen remote not found")
     end
 end
 

--- a/SnakeMovement
+++ b/SnakeMovement
@@ -6,6 +6,7 @@ local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
 local TweenService = game:GetService("TweenService")
 local Debris = game:GetService("Debris")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 -- 🔧 NETWORK-OPTIMIZED CONFIG SYSTEM
 local Config = {}
@@ -57,6 +58,31 @@ validateConfig()
 -- Player setup
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
+
+-- Movement control state
+local movementEnabled = true
+local heartbeatConnection = nil
+
+-- Setup remote event handlers for death/revive
+local remotes = ReplicatedStorage:WaitForChild("Remotes", 5)
+if remotes then
+    local stopMovementRemote = remotes:FindFirstChild("StopSnakeMovement")
+    local resumeMovementRemote = remotes:FindFirstChild("ResumeSnakeMovement")
+    
+    if stopMovementRemote then
+        stopMovementRemote.OnClientEvent:Connect(function()
+            print("🛑 Stopping snake movement - player died")
+            movementEnabled = false
+        end)
+    end
+    
+    if resumeMovementRemote then
+        resumeMovementRemote.OnClientEvent:Connect(function()
+            print("▶️ Resuming snake movement - player revived")
+            movementEnabled = true
+        end)
+    end
+end
 
 -- 📱 MOBILE SUPPORT
 -- Mobile detection and controls are handled through MobileHUD script
@@ -292,6 +318,9 @@ end
 local function initializeForCharacter(character)
 	cleanupSnake()
 	print(" Initializing new snake for character: " .. character.Name)
+	
+	-- Reset movement enabled when spawning
+	movementEnabled = true
 
 	local humanoid = character:WaitForChild("Humanoid")
 	local rootPart = character:WaitForChild("HumanoidRootPart")
@@ -566,6 +595,11 @@ local function initializeForCharacter(character)
 	heartbeatConnection = RunService.Heartbeat:Connect(function(dt)
 		if not rootPart or not rootPart.Parent then
 			cleanupSnake()
+			return
+		end
+		
+		-- Check if movement is enabled (disabled during death)
+		if not movementEnabled then
 			return
 		end
 

--- a/SnakeSystemIntegration
+++ b/SnakeSystemIntegration
@@ -386,8 +386,15 @@ end)
 -- Handle spawn requests from menu
 local respawnEvent = ReplicatedStorage:FindFirstChild("RespawnSnake")
 if respawnEvent then
-	respawnEvent.OnServerEvent:Connect(function(player)
+	respawnEvent.OnServerEvent:Connect(function(player, username)
 		print("🎮 Respawn requested for:", player.Name)
+		
+		-- Store username if provided
+		if username and type(username) == "string" then
+			player:SetAttribute("SlitherUsername", username)
+			print("📝 Username set to:", username)
+		end
+		
 		if player.Character then
 			player.Character:Destroy()
 		end

--- a/StarterPlayer/StarterPlayerScripts/DeathEffectHandler.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/DeathEffectHandler.client.lua
@@ -1,0 +1,73 @@
+--[[
+    DeathEffectHandler - Handles visual death effects on the client
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+
+-- Wait for remotes
+local remotes = ReplicatedStorage:WaitForChild("Remotes", 10)
+if not remotes then
+    warn("[DeathEffectHandler] Could not find Remotes folder")
+    return
+end
+
+local deathEffectRemote = remotes:WaitForChild("PlayerDeathEffect", 5)
+if not deathEffectRemote then
+    warn("[DeathEffectHandler] Could not find PlayerDeathEffect remote")
+    return
+end
+
+-- Handle death effect
+deathEffectRemote.OnClientEvent:Connect(function(deadPlayer, deathPosition)
+    -- Create a simple particle effect at death position
+    local effectPart = Instance.new("Part")
+    effectPart.Name = "DeathEffect"
+    effectPart.Anchored = true
+    effectPart.CanCollide = false
+    effectPart.Size = Vector3.new(1, 1, 1)
+    effectPart.Position = deathPosition
+    effectPart.Transparency = 1
+    effectPart.Parent = workspace
+    
+    -- Create particle emitter for death effect
+    local particleEmitter = Instance.new("ParticleEmitter")
+    particleEmitter.Texture = "rbxasset://textures/particles/sparkles_main.dds"
+    particleEmitter.Rate = 100
+    particleEmitter.Lifetime = NumberRange.new(0.5, 1)
+    particleEmitter.VelocityInheritance = 0
+    particleEmitter.EmissionDirection = Enum.NormalId.Top
+    particleEmitter.Speed = NumberRange.new(5, 15)
+    particleEmitter.SpreadAngle = Vector2.new(360, 360)
+    particleEmitter.Color = ColorSequence.new(Color3.new(1, 0.2, 0.2))
+    particleEmitter.LightEmission = 1
+    particleEmitter.LightInfluence = 0
+    particleEmitter.Size = NumberSequence.new({
+        NumberSequenceKeypoint.new(0, 2),
+        NumberSequenceKeypoint.new(0.5, 1.5),
+        NumberSequenceKeypoint.new(1, 0)
+    })
+    particleEmitter.Transparency = NumberSequence.new({
+        NumberSequenceKeypoint.new(0, 0),
+        NumberSequenceKeypoint.new(0.8, 0.5),
+        NumberSequenceKeypoint.new(1, 1)
+    })
+    particleEmitter.Parent = effectPart
+    
+    -- Stop emitting after a short burst
+    task.wait(0.1)
+    particleEmitter.Enabled = false
+    
+    -- Clean up after particles finish
+    Debris:AddItem(effectPart, 2)
+    
+    -- Optional: Add a sound effect if available
+    local deathSound = Instance.new("Sound")
+    deathSound.SoundId = "rbxasset://sounds/impact_water_low.mp3" -- Using a built-in sound
+    deathSound.Volume = 0.5
+    deathSound.Parent = effectPart
+    deathSound:Play()
+end)
+
+print("[DeathEffectHandler] Death effect handler initialized")


### PR DESCRIPTION
Fixes death and respawn flow by resolving a SpectatingState error and ensuring proper RemoteEvent setup.

The `SpectatingState` was attempting to call a non-existent `_enterSpectatorMode` method, preventing players from properly entering spectator mode and seeing the death menu. This PR adds the missing logic, ensures all necessary RemoteEvents for death, spectating, and respawning are correctly initialized, and updates the respawn handler to accept a username.

---
<a href="https://cursor.com/background-agent?bcId=bc-05aadce0-34c2-499b-bfb7-a3bd5ce67221">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05aadce0-34c2-499b-bfb7-a3bd5ce67221">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

