### PR TITLE
Initialize skinned mesh snake system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [11.2.0] - 2025-08-08
+- Skinned snake bone animation rewritten with NaN-safe framing:
+  - Introduced safeNormalize and orthonormal basis helpers to avoid divide-by-zero and invalid CFrames
+  - Implemented parallel-transport-style up-vector propagation to lock roll and eliminate “poking” artifacts
+  - Smoothed per-bone tangents to avoid sudden flips on tight turns
+  - Added clamped wave offset to prevent extreme rotations
+- Robust pathing:
+  - Optional Catmull–Rom spline with arc-length sampling; non-spline distance-based fallback added
+  - History sampling now guards zero-length segments and uses safe fallbacks
+- Mesh and bones:
+  - Auto-detect MeshPart named `Circle` with fallback to first MeshPart
+  - Collect all `Bone` descendants; numeric-aware sorting for names like `Bone`, `Bone.001`, `Bone.002`, …
+- Physics safety:
+  - Disabled collisions (`CanCollide=false`, `CanQuery=false`, `Massless=true`) for all `BasePart` descendants of the cloned snake model to prevent flinging
+  - Explicit weld to `HumanoidRootPart` after settling
+- Visual stability:
+  - Color cycling hardened: falls back to `HeadColor` when `BodyColors` missing/empty
+- API compatibility:
+  - Expose `init`, `createSnake`, `createSnakeFromSavedState`, plus `updateLength` and `updateConfig`
+
+## [11.1.0] - 2025-08-07
+- Initial skinned mesh migration and bone-following using position history
+- Added LOD with frequency throttling
+- Introduced head light and boost particles

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# snakegod
+# Project Overview
+
+This project implements a high-performance, skinned-mesh snake system with procedural bone animation.
+
+## Stability Improvements (v11.2.0)
+- Robust, NaN-safe bone animation:
+  - Parallel-transport style up-vector propagation to eliminate roll jitter and vertex explosions
+  - Safe normalization and orthonormal basis to prevent divide-by-zero
+  - Smoothed tangents and clamped wave rotation for stability
+- Physics safety:
+  - All BaseParts under the cloned snake model have `CanCollide=false`, `CanQuery=false`, and `Massless=true`
+  - Mesh is welded to `HumanoidRootPart` after physics settle
+- Pathing:
+  - Optional Catmull–Rom spline (arc-length); distance-based fallback requires no extra modules
+
+## Mesh Requirements
+- Place your skinned snake model in `ReplicatedStorage` as `slither_snake_rigged` (recommended), or `SkinnedSnakeTemplate`.
+- Preferred structure:
+  - A `MeshPart` named `Circle` (used as the deforming mesh)
+  - Bones under the mesh (e.g., `Bone`, `Bone.001`, `Bone.002`, …)
+  - Optional: `InitialPoses` folder with saved transforms
+
+## Getting Started
+- Client requires `ReplicatedStorage/OptimizedSnakeSystemV9.lua`
+- API:
+  - `OptimizedSnakeSystemV9.init()`
+  - `OptimizedSnakeSystemV9.createSnake(character, config)`
+  - `snake:updateLength(newLength)`
+  - `snake:updateConfig({ HeadColor, BodyColors })`
+
+## Troubleshooting
+- If the snake doesn’t render:
+  - Confirm your model is in `ReplicatedStorage` and named `slither_snake_rigged` or `SkinnedSnakeTemplate`
+  - Ensure there is a `MeshPart` (ideally named `Circle`) and it contains `Bone` instances
+- If bones tilt upwards or roll:
+  - The new framing stabilizes roll; adjust `DEFAULT_BONE_SPACING` and `BONE_BLEND_FACTOR` in `OptimizedSnakeSystemV9.lua` for feel

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -1,5 +1,5 @@
--- Optimized Snake System V11 - SKINNED MESH REVOLUTION
--- Complete rewrite to use a single skinned mesh with bone-based animation
+-- Optimized Snake System V11.2 - SKINNED MESH WITH PARALLEL-TRANSPORT FRAMING
+-- Stable, NaN-safe bone animation with roll-lock and collision-safe assembly
 -- Zero gaps, maximum performance, and professional-grade visuals
 
 local Players = game:GetService("Players")

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -234,6 +234,15 @@ function SkinnedSnake:createSkinnedMesh()
     cloned.Name = "SnakeBody"
     cloned.Parent = self.model
 
+    -- Disable collisions on all BaseParts to avoid physics conflicts
+    for _, d in ipairs(cloned:GetDescendants()) do
+        if d:IsA("BasePart") then
+            d.CanCollide = false
+            d.CanQuery = false
+            d.Massless = true
+        end
+    end
+
     -- If it's a model, prefer MeshPart named 'Circle', else first MeshPart
     if cloned:IsA("Model") then
         self.meshPart = cloned:FindFirstChild("Circle")

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -453,26 +453,84 @@ local function getHistoryAtBackDistance(self, targetBackDistance)
     }
 end
 
-local function computeStableUp(prevUp: Vector3, tangent: Vector3)
-    local worldUp = Vector3.new(0, 1, 0)
-    local t = tangent.Magnitude > 0 and tangent.Unit or Vector3.new(0, 0, -1)
+-- === Robust, NaN-safe vector and frame helpers ===
+local EPS = 1e-6
 
-    -- Project previous up onto plane perpendicular to tangent (parallel transport)
-    local upProj = prevUp - t * prevUp:Dot(t)
-    if upProj.Magnitude < 1e-3 then
-        -- Fallback to world up if projection is near zero (tangent ~ parallel to up)
-        upProj = worldUp - t * worldUp:Dot(t)
-        if upProj.Magnitude < 1e-3 then
-            -- Final fallback: any orthonormal up
-            upProj = Vector3.new(1, 0, 0)
-        end
+local function isValidVector3(v: Vector3): boolean
+    return v and (v.X == v.X) and (v.Y == v.Y) and (v.Z == v.Z)
+end
+
+local function safeNormalize(v: Vector3, fallback: Vector3): Vector3
+    if not isValidVector3(v) then return fallback end
+    local m = v.Magnitude
+    if not m or m < EPS or m ~= m then
+        return fallback
     end
-    local up = upProj.Unit
-    local right = t:Cross(up).Unit
-    -- Re-orthogonalize up to ensure perfect basis
-    up = right:Cross(t).Unit
+    return v / m
+end
 
-    return up
+local WORLD_AXES = {
+    Vector3.new(1, 0, 0),
+    Vector3.new(0, 1, 0),
+    Vector3.new(0, 0, 1)
+}
+
+local function orthonormalBasis(prevUp: Vector3, tangent: Vector3)
+    local t = safeNormalize(tangent, Vector3.new(0, 0, -1))
+
+    -- Try parallel transport from previous up
+    local up = prevUp - t * prevUp:Dot(t)
+    up = safeNormalize(up, Vector3.new(0, 1, 0))
+
+    -- If still near-degenerate, choose the world axis least parallel to t
+    if up.Magnitude < 0.5 then
+        local bestAxis = WORLD_AXES[1]
+        local bestDot = math.abs(t:Dot(bestAxis))
+        for i = 2, #WORLD_AXES do
+            local dotv = math.abs(t:Dot(WORLD_AXES[i]))
+            if dotv < bestDot then
+                bestDot = dotv
+                bestAxis = WORLD_AXES[i]
+            end
+        end
+        up = bestAxis - t * bestAxis:Dot(t)
+        up = safeNormalize(up, Vector3.new(0, 1, 0))
+    end
+
+    local right = t:Cross(up)
+    right = safeNormalize(right, Vector3.new(1, 0, 0))
+    up = right:Cross(t)
+    up = safeNormalize(up, Vector3.new(0, 1, 0))
+
+    return t, right, up
+end
+
+local function safeCFrameFromTRU(pos: Vector3, t: Vector3, r: Vector3, u: Vector3)
+    -- Validate vectors; rebuild basis if necessary
+    if not isValidVector3(pos) then pos = Vector3.new() end
+    local tt = safeNormalize(t, Vector3.new(0, 0, -1))
+    local rr = r
+    local uu = u
+
+    -- Ensure rr, uu are valid and orthonormal to t
+    if not isValidVector3(rr) or rr.Magnitude < 0.5 then
+        rr = tt:Cross(Vector3.new(0, 1, 0))
+        if rr.Magnitude < EPS then
+            rr = tt:Cross(Vector3.new(1, 0, 0))
+        end
+        rr = safeNormalize(rr, Vector3.new(1, 0, 0))
+    end
+    uu = rr:Cross(tt)
+    uu = safeNormalize(uu, Vector3.new(0, 1, 0))
+
+    -- Final re-orthogonalization
+    rr = tt:Cross(uu)
+    rr = safeNormalize(rr, Vector3.new(1, 0, 0))
+    uu = rr:Cross(tt)
+    uu = safeNormalize(uu, Vector3.new(0, 1, 0))
+
+    local cf = CFrame.fromMatrix(pos, rr, uu)
+    return cf
 end
 
 local function buildControlPointsFromHistory(self, count)
@@ -526,29 +584,32 @@ function SkinnedSnake:updateBones(deltaTime)
         local totalBoneLength = math.max(0, (#self.bones - 1) * self.boneSpacing)
         local startOffset = math.max(0, splineLength - totalBoneLength)
 
-        -- Propagate a stable up-vector along the chain to prevent roll/poking
+        -- Propagate stable frame along the chain
         local chainPrevUp = Vector3.new(0, 1, 0)
 
         for i, bone in ipairs(self.bones) do
             local distance = startOffset + (i - 1) * self.boneSpacing
-            local t = math.clamp(distance / splineLength, 0, 1)
+            local tParam = math.clamp(distance / splineLength, 0, 1)
 
-            local position = spline:GetPoint(t)
-            local tangent = spline:GetTangent(t)
+            local position = spline:GetPoint(tParam)
+            local rawTangent = spline:GetTangent(tParam)
 
-            -- Stable frame with minimal roll change
-            local up = computeStableUp(self.previousUpVectors[bone] or chainPrevUp, tangent)
-            chainPrevUp = up
-            self.previousUpVectors[bone] = up
+            -- Smooth tangent to reduce sudden flips
+            local prevT = self.previousTangents and self.previousTangents[bone] or rawTangent
+            local smoothedT = (prevT * 0.6 + rawTangent * 0.4)
+            smoothedT = safeNormalize(smoothedT, rawTangent)
+            self.previousTangents = self.previousTangents or {}
+            self.previousTangents[bone] = smoothedT
 
-            -- Build a stable frame to lock roll
-            local tt = tangent.Unit
-            local right = tt:Cross(up).Unit
-            local trueUp = right:Cross(tt).Unit
-            local worldCFrame = CFrame.fromMatrix(position, right, trueUp)
+            -- Robust orthonormal basis
+            local tVec, rVec, uVec = orthonormalBasis(self.previousUpVectors[bone] or chainPrevUp, smoothedT)
+            chainPrevUp = uVec
+            self.previousUpVectors[bone] = uVec
 
-            -- Optional subtle waving in local right axis for life-like motion
-            local wave = math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1)
+            local worldCFrame = safeCFrameFromTRU(position, tVec, rVec, uVec)
+
+            -- Subtle wave, clamped
+            local wave = math.clamp(math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1), -0.2, 0.2)
             worldCFrame = worldCFrame * CFrame.Angles(0, 0, wave)
 
             -- Convert to mesh-local space
@@ -576,18 +637,20 @@ function SkinnedSnake:updateBones(deltaTime)
         local backDistance = (i - 1) * self.boneSpacing
         local sample = getHistoryAtBackDistance(self, backDistance)
         local pos = sample.position
-        local tangent = sample.direction
+        local rawTangent = sample.direction
 
-        local up = computeStableUp(self.previousUpVectors[bone] or chainPrevUp, tangent)
-        chainPrevUp = up
-        self.previousUpVectors[bone] = up
+        local prevT = self.previousTangents and self.previousTangents[bone] or rawTangent
+        local smoothedT = (prevT * 0.6 + rawTangent * 0.4)
+        smoothedT = safeNormalize(smoothedT, rawTangent)
+        self.previousTangents = self.previousTangents or {}
+        self.previousTangents[bone] = smoothedT
 
-        local tt = tangent.Unit
-        local right = tt:Cross(up).Unit
-        local trueUp = right:Cross(tt).Unit
-        local worldCFrame = CFrame.fromMatrix(pos, right, trueUp)
+        local tVec, rVec, uVec = orthonormalBasis(self.previousUpVectors[bone] or chainPrevUp, smoothedT)
+        chainPrevUp = uVec
+        self.previousUpVectors[bone] = uVec
 
-        local wave = math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1)
+        local worldCFrame = safeCFrameFromTRU(pos, tVec, rVec, uVec)
+        local wave = math.clamp(math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1), -0.2, 0.2)
         worldCFrame = worldCFrame * CFrame.Angles(0, 0, wave)
 
         local relativeTransform = meshCFrame:Inverse() * worldCFrame

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -234,9 +234,10 @@ function SkinnedSnake:createSkinnedMesh()
     cloned.Name = "SnakeBody"
     cloned.Parent = self.model
 
-    -- If it's a model, find its MeshPart
+    -- If it's a model, prefer MeshPart named 'Circle', else first MeshPart
     if cloned:IsA("Model") then
-        self.meshPart = cloned:FindFirstChildOfClass("MeshPart")
+        self.meshPart = cloned:FindFirstChild("Circle")
+            or cloned:FindFirstChildOfClass("MeshPart")
     else
         self.meshPart = cloned
     end
@@ -277,21 +278,32 @@ function SkinnedSnake:createSkinnedMesh()
     self.meshPart:SetAttribute("OwnerName", self.player.Name)
     self.meshPart:SetAttribute("PlayerUserId", self.player.UserId)
     
-    -- Find bones directly under the mesh
+    -- Find bones: collect all Bone descendants under the mesh; if too few, search whole model
     self.bones = {}
-    local function findBones(parent)
-        for _, child in pairs(parent:GetChildren()) do
-            if child:IsA("Bone") then
-                table.insert(self.bones, child)
-            else
-                findBones(child)
+    for _, desc in ipairs(self.meshPart:GetDescendants()) do
+        if desc:IsA("Bone") then
+            table.insert(self.bones, desc)
+        end
+    end
+    if #self.bones < 2 then
+        -- Fallback: search entire cloned model in case bones aren't strictly under selected mesh
+        self.bones = {}
+        for _, desc in ipairs(cloned:GetDescendants()) do
+            if desc:IsA("Bone") then
+                table.insert(self.bones, desc)
             end
         end
     end
-    findBones(self.meshPart)
 
-    -- If multiple naming schemes, try sorting by name as fallback
+    -- Numeric-aware sort: Bone, Bone.001, Bone.002, ...
+    local function boneOrder(name)
+        if name == "Bone" then return 0 end
+        local n = name:match("Bone%%.(%d+)") or name:match("Bone[_ ]?(%d+)")
+        return tonumber(n) or math.huge
+    end
     table.sort(self.bones, function(a, b)
+        local oa, ob = boneOrder(a.Name), boneOrder(b.Name)
+        if oa ~= ob then return oa < ob end
         return a.Name < b.Name
     end)
 

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -10,8 +10,11 @@ local TweenService = game:GetService("TweenService")
 local Debris = game:GetService("Debris")
 local UserInputService = RunService:IsClient() and game:GetService("UserInputService") or nil
 
--- Add spline dependency for smooth, arc-length based sampling
-local CatmullRomSpline = require(ReplicatedStorage:WaitForChild("CatmullRomSpline"))
+-- Add spline dependency for smooth, arc-length based sampling (safe require with timeout)
+local CatmullRomSpline = nil
+pcall(function()
+    CatmullRomSpline = require(ReplicatedStorage:WaitForChild("CatmullRomSpline", 1))
+end)
 
 -- Constants for the skinned mesh system
 local MESH_ASSET_ID = "rbxassetid://YOUR_MESH_ID" -- Will be replaced with actual asset ID
@@ -396,6 +399,48 @@ function SkinnedSnake:getHistoricalPosition(segmentsBack)
     return self.positionHistory[targetIndex] or self.positionHistory[self.historyIndex]
 end
 
+function SkinnedSnake:getHistoricalData(stepsBack)
+    -- Existing helper kept for simple fallback usage
+    local targetIndex = ((self.historyIndex - stepsBack - 1) % HISTORY_SIZE) + 1
+    return self.positionHistory[targetIndex] or self.positionHistory[self.historyIndex]
+end
+
+-- Helper: sample history by traveled distance backwards from current index
+local function getHistoryAtBackDistance(self, targetBackDistance)
+    if not self.positionHistory or self.historyIndex == 0 then
+        return nil
+    end
+    local accumulated = 0
+    local idx = self.historyIndex
+    local current = self.positionHistory[idx]
+    local prevIdx = ((idx - 2) % HISTORY_SIZE) + 1
+    while accumulated < targetBackDistance do
+        local prev = self.positionHistory[prevIdx]
+        if not prev then break end
+        local segment = (current.position - prev.position).Magnitude
+        accumulated = accumulated + segment
+        if accumulated >= targetBackDistance then
+            -- Interpolate between prev and current to hit exact distance
+            local overshoot = accumulated - targetBackDistance
+            local t = segment > 0 and (1 - overshoot / segment) or 1
+            local pos = prev.position:Lerp(current.position, t)
+            local dir = (current.position - prev.position)
+            dir = dir.Magnitude > 1e-3 and dir.Unit or Vector3.new(0, 0, -1)
+            return { position = pos, direction = dir }
+        end
+        -- step back
+        current = prev
+        idx = prevIdx
+        prevIdx = ((prevIdx - 2) % HISTORY_SIZE) + 1
+        if prevIdx == idx then break end
+    end
+    -- Fallback to oldest available
+    return {
+        position = current and current.position or self.rootPart.Position,
+        direction = current and (current.direction or self.rootPart.CFrame.LookVector) or self.rootPart.CFrame.LookVector
+    }
+end
+
 local function computeStableUp(prevUp: Vector3, tangent: Vector3)
     local worldUp = Vector3.new(0, 1, 0)
     local t = tangent.Magnitude > 0 and tangent.Unit or Vector3.new(0, 0, -1)
@@ -450,57 +495,93 @@ end
 function SkinnedSnake:updateBones(deltaTime)
     if not self.bones or #self.bones == 0 then return end
 
-    -- Build a spline from recent motion for arc-length sampling
-    local controlPoints = buildControlPointsFromHistory(self, CONTROL_POINT_COUNT)
-    if #controlPoints < 4 then return end
-
-    local spline = CatmullRomSpline.new(controlPoints)
-    if not spline then return end
-    spline:SetUniform(true)
-
-    -- Determine total spline length
-    local splineLength = spline:GetLength()
-    if splineLength <= 0 then return end
-
-    -- Total length needed for all bones along body
-    local totalBoneLength = math.max(0, (#self.bones - 1) * self.boneSpacing)
-    local startOffset = math.max(0, splineLength - totalBoneLength)
-
     local meshCFrame = self.meshPart.CFrame
 
-    -- Propagate a stable up-vector along the chain to prevent roll/poking
+    if CatmullRomSpline then
+        -- Build a spline from recent motion for arc-length sampling
+        local controlPoints = buildControlPointsFromHistory(self, CONTROL_POINT_COUNT)
+        if #controlPoints < 4 then return end
+
+        local spline = CatmullRomSpline.new(controlPoints)
+        if not spline then return end
+        spline:SetUniform(true)
+
+        -- Determine total spline length
+        local splineLength = spline:GetLength()
+        if splineLength <= 0 then return end
+
+        -- Total length needed for all bones along body
+        local totalBoneLength = math.max(0, (#self.bones - 1) * self.boneSpacing)
+        local startOffset = math.max(0, splineLength - totalBoneLength)
+
+        -- Propagate a stable up-vector along the chain to prevent roll/poking
+        local chainPrevUp = Vector3.new(0, 1, 0)
+
+        for i, bone in ipairs(self.bones) do
+            local distance = startOffset + (i - 1) * self.boneSpacing
+            local t = math.clamp(distance / splineLength, 0, 1)
+
+            local position = spline:GetPoint(t)
+            local tangent = spline:GetTangent(t)
+
+            -- Stable frame with minimal roll change
+            local up = computeStableUp(self.previousUpVectors[bone] or chainPrevUp, tangent)
+            chainPrevUp = up
+            self.previousUpVectors[bone] = up
+
+            -- Build a stable frame to lock roll
+            local tt = tangent.Unit
+            local right = tt:Cross(up).Unit
+            local trueUp = right:Cross(tt).Unit
+            local worldCFrame = CFrame.fromMatrix(position, right, trueUp)
+
+            -- Optional subtle waving in local right axis for life-like motion
+            local wave = math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1)
+            worldCFrame = worldCFrame * CFrame.Angles(0, 0, wave)
+
+            -- Convert to mesh-local space
+            local relativeTransform = meshCFrame:Inverse() * worldCFrame
+
+            -- Apply initial bone offset from rig
+            local initialOffset = self.boneOffsets[bone] or CFrame.new()
+            relativeTransform = relativeTransform * initialOffset
+
+            -- Smooth the transform to avoid jitter
+            local previous = self.previousTransforms[bone]
+            if previous then
+                relativeTransform = previous:Lerp(relativeTransform, BONE_BLEND_FACTOR)
+            end
+
+            bone.Transform = relativeTransform
+            self.previousTransforms[bone] = relativeTransform
+        end
+        return
+    end
+
+    -- Fallback path: sample history by distance without spline module
     local chainPrevUp = Vector3.new(0, 1, 0)
-
     for i, bone in ipairs(self.bones) do
-        local distance = startOffset + (i - 1) * self.boneSpacing
-        local t = math.clamp(distance / splineLength, 0, 1)
+        local backDistance = (i - 1) * self.boneSpacing
+        local sample = getHistoryAtBackDistance(self, backDistance)
+        local pos = sample.position
+        local tangent = sample.direction
 
-        local position = spline:GetPoint(t)
-        local tangent = spline:GetTangent(t)
-
-        -- Stable frame with minimal roll change
         local up = computeStableUp(self.previousUpVectors[bone] or chainPrevUp, tangent)
         chainPrevUp = up
         self.previousUpVectors[bone] = up
 
-        -- Build a stable frame to lock roll
-        local t = tangent.Unit
-        local right = t:Cross(up).Unit
-        local trueUp = right:Cross(t).Unit
-        local worldCFrame = CFrame.fromMatrix(position, right, trueUp)
+        local tt = tangent.Unit
+        local right = tt:Cross(up).Unit
+        local trueUp = right:Cross(tt).Unit
+        local worldCFrame = CFrame.fromMatrix(pos, right, trueUp)
 
-        -- Optional subtle waving in local right axis for life-like motion
         local wave = math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1)
         worldCFrame = worldCFrame * CFrame.Angles(0, 0, wave)
 
-        -- Convert to mesh-local space
         local relativeTransform = meshCFrame:Inverse() * worldCFrame
-
-        -- Apply initial bone offset from rig
         local initialOffset = self.boneOffsets[bone] or CFrame.new()
         relativeTransform = relativeTransform * initialOffset
 
-        -- Smooth the transform to avoid jitter
         local previous = self.previousTransforms[bone]
         if previous then
             relativeTransform = previous:Lerp(relativeTransform, BONE_BLEND_FACTOR)

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -10,6 +10,9 @@ local TweenService = game:GetService("TweenService")
 local Debris = game:GetService("Debris")
 local UserInputService = RunService:IsClient() and game:GetService("UserInputService") or nil
 
+-- Add spline dependency for smooth, arc-length based sampling
+local CatmullRomSpline = require(ReplicatedStorage:WaitForChild("CatmullRomSpline"))
+
 -- Constants for the skinned mesh system
 local MESH_ASSET_ID = "rbxassetid://YOUR_MESH_ID" -- Will be replaced with actual asset ID
 local BONE_COUNT = 15 -- Should match the number of bones in your Blender model
@@ -37,6 +40,11 @@ local WAVE_FREQUENCY = 2.0 -- How fast the wave travels down the body
 -- Growth Constants
 local GROWTH_RATE = 0.1 -- How fast the snake grows (units per food)
 local SCALE_PER_LENGTH = 0.005 -- How much the scale increases per length unit
+
+-- NEW smoothing/spacing constants for bones
+local DEFAULT_BONE_SPACING = 2.5 -- Studs between bones along the spline
+local BONE_BLEND_FACTOR = 0.6 -- 0..1 smoothing each frame (higher = snappier)
+local CONTROL_POINT_COUNT = 10 -- Control points to build the spline from recent motion
 
 -- LOD System for performance
 local LOD_DISTANCES = {
@@ -80,6 +88,13 @@ function SkinnedSnake.new(character, config)
     self.historyIndex = 0
     self.wavePhase = 0
     self.targetDirection = self.rootPart.CFrame.LookVector
+
+    -- Bone animation state
+    self.boneSpacing = DEFAULT_BONE_SPACING
+    self.originalBoneTransforms = {}
+    self.previousTransforms = {}
+    self.boneOffsets = {}
+    self.previousUpVectors = {}
     
     -- Visual state
     self.currentColorIndex = 1
@@ -135,11 +150,115 @@ function SkinnedSnake:createSkinnedMesh()
     self.model.Name = "SkinnedSnake_" .. self.player.Name
     self.model.Parent = workspace
     
-    -- Load the skinned mesh from ReplicatedStorage
-    local meshTemplate = ReplicatedStorage:WaitForChild("Meshes"):WaitForChild("untitledsnakeeeee")
-    self.meshPart = meshTemplate:Clone()
-    self.meshPart.Name = "SnakeBody"
-    self.meshPart.Parent = self.model
+    -- Try to locate a skinned mesh template in ReplicatedStorage
+    local templateModel = ReplicatedStorage:FindFirstChild("SkinnedSnakeTemplate")
+        or ReplicatedStorage:FindFirstChild("slither_snake_rigged")
+        or ReplicatedStorage:FindFirstChild("untitledsnakeeeee")
+
+    -- Fallback: look under a Meshes folder or any MeshPart child
+    if not templateModel then
+        local meshesFolder = ReplicatedStorage:FindFirstChild("Meshes")
+        if meshesFolder then
+            templateModel = meshesFolder:FindFirstChildOfClass("MeshPart")
+                or meshesFolder:FindFirstChildOfClass("Model")
+        end
+    end
+
+    -- Final fallback: search any MeshPart directly under ReplicatedStorage
+    if not templateModel then
+        for _, child in ipairs(ReplicatedStorage:GetChildren()) do
+            if child:IsA("MeshPart") or child:IsA("Model") then
+                templateModel = child
+                break
+            end
+        end
+    end
+
+    if not templateModel then
+        warn("[OptimizedSnakeSystemV9] No skinned mesh template found in ReplicatedStorage. Using fallback part.")
+        -- Minimal fallback visual so game continues without errors
+        local fallback = Instance.new("Part")
+        fallback.Name = "SnakeFallback"
+        fallback.Size = Vector3.new(4, 4, 4)
+        fallback.Material = Enum.Material.Neon
+        fallback.Color = self.config.HeadColor
+        fallback.CanCollide = false
+        fallback.CanQuery = false
+        fallback.Anchored = false
+        fallback.Parent = self.model
+        self.meshPart = fallback
+
+        local weld = Instance.new("WeldConstraint")
+        weld.Part0 = self.meshPart
+        weld.Part1 = self.rootPart
+        weld.Parent = self.meshPart
+        self.meshPart.CFrame = self.rootPart.CFrame
+
+        self.bones = {}
+        self:addVisualEffects()
+        return
+    end
+
+    -- Clone the template
+    local cloned
+    if templateModel:IsA("MeshPart") then
+        cloned = templateModel:Clone()
+    elseif templateModel:IsA("Model") then
+        cloned = templateModel:Clone()
+    else
+        warn("[OptimizedSnakeSystemV9] Template found but not a Model/MeshPart. Using fallback part.")
+        local fallback = Instance.new("Part")
+        fallback.Name = "SnakeFallback"
+        fallback.Size = Vector3.new(4, 4, 4)
+        fallback.Material = Enum.Material.Neon
+        fallback.Color = self.config.HeadColor
+        fallback.CanCollide = false
+        fallback.CanQuery = false
+        fallback.Anchored = false
+        fallback.Parent = self.model
+        self.meshPart = fallback
+        local weld = Instance.new("WeldConstraint")
+        weld.Part0 = self.meshPart
+        weld.Part1 = self.rootPart
+        weld.Parent = self.meshPart
+        self.meshPart.CFrame = self.rootPart.CFrame
+        self.bones = {}
+        self:addVisualEffects()
+        return
+    end
+
+    -- Adopt cloned asset
+    cloned.Name = "SnakeBody"
+    cloned.Parent = self.model
+
+    -- If it's a model, find its MeshPart
+    if cloned:IsA("Model") then
+        self.meshPart = cloned:FindFirstChildOfClass("MeshPart")
+    else
+        self.meshPart = cloned
+    end
+
+    if not self.meshPart then
+        warn("[OptimizedSnakeSystemV9] Cloned template does not contain a MeshPart. Using fallback part.")
+        local fallback = Instance.new("Part")
+        fallback.Name = "SnakeFallback"
+        fallback.Size = Vector3.new(4, 4, 4)
+        fallback.Material = Enum.Material.Neon
+        fallback.Color = self.config.HeadColor
+        fallback.CanCollide = false
+        fallback.CanQuery = false
+        fallback.Anchored = false
+        fallback.Parent = self.model
+        self.meshPart = fallback
+        local weld = Instance.new("WeldConstraint")
+        weld.Part0 = self.meshPart
+        weld.Part1 = self.rootPart
+        weld.Parent = self.meshPart
+        self.meshPart.CFrame = self.rootPart.CFrame
+        self.bones = {}
+        self:addVisualEffects()
+        return
+    end
     
     -- Set up the mesh properties
     self.meshPart.Anchored = false
@@ -155,45 +274,36 @@ function SkinnedSnake:createSkinnedMesh()
     self.meshPart:SetAttribute("OwnerName", self.player.Name)
     self.meshPart:SetAttribute("PlayerUserId", self.player.UserId)
     
-    -- Find the armature and bones
-    self.armature = self.meshPart:FindFirstChildOfClass("Humanoid") or self.meshPart:FindFirstChildOfClass("AnimationController")
-    if not self.armature then
-        -- Look for bones directly
-        self.bones = {}
-        local function findBones(parent)
-            for _, child in pairs(parent:GetChildren()) do
-                if child:IsA("Bone") then
-                    table.insert(self.bones, child)
-                elseif child:IsA("Model") or child:IsA("Folder") then
-                    findBones(child)
-                end
-            end
-        end
-        findBones(self.meshPart)
-        
-        -- Sort bones by name or position
-        table.sort(self.bones, function(a, b)
-            return a.Name < b.Name
-        end)
-    else
-        -- Get bones from armature
-        self.bones = {}
-        local rootBone = self.armature:FindFirstChild("Bone")
-        if rootBone then
-            local currentBone = rootBone
-            while currentBone do
-                table.insert(self.bones, currentBone)
-                currentBone = currentBone:FindFirstChildOfClass("Bone")
+    -- Find bones directly under the mesh
+    self.bones = {}
+    local function findBones(parent)
+        for _, child in pairs(parent:GetChildren()) do
+            if child:IsA("Bone") then
+                table.insert(self.bones, child)
+            else
+                findBones(child)
             end
         end
     end
-    
+    findBones(self.meshPart)
+
+    -- If multiple naming schemes, try sorting by name as fallback
+    table.sort(self.bones, function(a, b)
+        return a.Name < b.Name
+    end)
+
     print("Found", #self.bones, "bones in the mesh")
-    
-    -- Store original bone transforms
+
+    -- Store original bone transforms and initialize smoothing state
     self.originalBoneTransforms = {}
+    self.previousTransforms = {}
+    self.boneOffsets = {}
+    self.previousUpVectors = {}
     for i, bone in ipairs(self.bones) do
         self.originalBoneTransforms[i] = bone.Transform
+        self.boneOffsets[bone] = bone.Transform
+        self.previousTransforms[bone] = bone.Transform
+        self.previousUpVectors[bone] = Vector3.new(0, 1, 0)
     end
     
     -- Add visual effects
@@ -286,46 +396,118 @@ function SkinnedSnake:getHistoricalPosition(segmentsBack)
     return self.positionHistory[targetIndex] or self.positionHistory[self.historyIndex]
 end
 
+local function computeStableUp(prevUp: Vector3, tangent: Vector3)
+    local worldUp = Vector3.new(0, 1, 0)
+    local t = tangent.Magnitude > 0 and tangent.Unit or Vector3.new(0, 0, -1)
+
+    -- Project previous up onto plane perpendicular to tangent (parallel transport)
+    local upProj = prevUp - t * prevUp:Dot(t)
+    if upProj.Magnitude < 1e-3 then
+        -- Fallback to world up if projection is near zero (tangent ~ parallel to up)
+        upProj = worldUp - t * worldUp:Dot(t)
+        if upProj.Magnitude < 1e-3 then
+            -- Final fallback: any orthonormal up
+            upProj = Vector3.new(1, 0, 0)
+        end
+    end
+    local up = upProj.Unit
+    local right = t:Cross(up).Unit
+    -- Re-orthogonalize up to ensure perfect basis
+    up = right:Cross(t).Unit
+
+    return up
+end
+
+local function buildControlPointsFromHistory(self, count)
+    local points = {}
+    if not self.positionHistory or self.historyIndex == 0 then
+        return points
+    end
+
+    -- Sample evenly from recent history
+    local step = math.max(1, math.floor(HISTORY_SIZE / math.max(4, count)))
+    local idx = self.historyIndex
+    for i = 1, count do
+        local h = self.positionHistory[idx]
+        if h then
+            table.insert(points, 1, h.position) -- prepend to keep chronological order
+        end
+        idx = ((idx - step - 1) % HISTORY_SIZE) + 1
+    end
+
+    -- Ensure at least 4 points by duplicating ends if needed
+    while #points < 4 do
+        if #points == 0 then
+            table.insert(points, self.rootPart.Position)
+        else
+            table.insert(points, points[#points])
+        end
+    end
+
+    return points
+end
+
 function SkinnedSnake:updateBones(deltaTime)
     if not self.bones or #self.bones == 0 then return end
-    
-    -- Update wave phase for natural movement
-    self.wavePhase = self.wavePhase + WAVE_FREQUENCY * deltaTime
-    
-    -- Calculate how many segments each bone represents
-    local segmentsPerBone = math.max(1, self.length / #self.bones)
-    
+
+    -- Build a spline from recent motion for arc-length sampling
+    local controlPoints = buildControlPointsFromHistory(self, CONTROL_POINT_COUNT)
+    if #controlPoints < 4 then return end
+
+    local spline = CatmullRomSpline.new(controlPoints)
+    if not spline then return end
+    spline:SetUniform(true)
+
+    -- Determine total spline length
+    local splineLength = spline:GetLength()
+    if splineLength <= 0 then return end
+
+    -- Total length needed for all bones along body
+    local totalBoneLength = math.max(0, (#self.bones - 1) * self.boneSpacing)
+    local startOffset = math.max(0, splineLength - totalBoneLength)
+
+    local meshCFrame = self.meshPart.CFrame
+
+    -- Propagate a stable up-vector along the chain to prevent roll/poking
+    local chainPrevUp = Vector3.new(0, 1, 0)
+
     for i, bone in ipairs(self.bones) do
-        -- Get historical position for this bone
-        local segmentOffset = (i - 1) * segmentsPerBone
-        local historicalData = self:getHistoricalPosition(segmentOffset)
-        
-        -- Calculate the target position for this bone
-        local targetPos = historicalData.position
-        local targetLook = historicalData.lookVector
-        
-        -- Add wave motion for natural slithering
-        local waveOffset = math.sin(self.wavePhase - (i * 0.5)) * WAVE_AMPLITUDE
-        local perpendicular = targetLook:Cross(Vector3.new(0, 1, 0)).Unit
-        
-        -- Apply wave motion
-        local wavePosition = targetPos + perpendicular * waveOffset
-        
-        -- Calculate bone transform
-        local boneOffset = i == 1 and 0 or (i - 1) / (#self.bones - 1)
-        local scaleFactor = 1 - (boneOffset * 0.3) -- Taper towards tail
-        
-        -- Apply the transform to the bone
-        if i == 1 then
-            -- Head bone follows root part more closely
-            bone.Transform = self.originalBoneTransforms[i] * CFrame.new(0, 0, 0)
-        else
-            -- Body bones follow with wave motion
-            local localOffset = self.meshPart.CFrame:ToObjectSpace(CFrame.new(wavePosition))
-            bone.Transform = self.originalBoneTransforms[i] * 
-                           CFrame.new(localOffset.Position * 0.1) * 
-                           CFrame.Angles(0, waveOffset * 0.1, 0)
+        local distance = startOffset + (i - 1) * self.boneSpacing
+        local t = math.clamp(distance / splineLength, 0, 1)
+
+        local position = spline:GetPoint(t)
+        local tangent = spline:GetTangent(t)
+
+        -- Stable frame with minimal roll change
+        local up = computeStableUp(self.previousUpVectors[bone] or chainPrevUp, tangent)
+        chainPrevUp = up
+        self.previousUpVectors[bone] = up
+
+        -- Build a stable frame to lock roll
+        local t = tangent.Unit
+        local right = t:Cross(up).Unit
+        local trueUp = right:Cross(t).Unit
+        local worldCFrame = CFrame.fromMatrix(position, right, trueUp)
+
+        -- Optional subtle waving in local right axis for life-like motion
+        local wave = math.sin((tick() * WAVE_FREQUENCY) - i * 0.3) * (WAVE_AMPLITUDE * 0.1)
+        worldCFrame = worldCFrame * CFrame.Angles(0, 0, wave)
+
+        -- Convert to mesh-local space
+        local relativeTransform = meshCFrame:Inverse() * worldCFrame
+
+        -- Apply initial bone offset from rig
+        local initialOffset = self.boneOffsets[bone] or CFrame.new()
+        relativeTransform = relativeTransform * initialOffset
+
+        -- Smooth the transform to avoid jitter
+        local previous = self.previousTransforms[bone]
+        if previous then
+            relativeTransform = previous:Lerp(relativeTransform, BONE_BLEND_FACTOR)
         end
+
+        bone.Transform = relativeTransform
+        self.previousTransforms[bone] = relativeTransform
     end
 end
 
@@ -420,6 +602,22 @@ function SkinnedSnake:updateColors()
     end
 end
 
+function SkinnedSnake:updateLength(newLength)
+    self.length = math.clamp(tonumber(newLength) or self.length, MIN_SNAKE_LENGTH, MAX_SNAKE_LENGTH)
+end
+
+function SkinnedSnake:updateConfig(newConfig)
+    if not newConfig then return end
+    if newConfig.HeadColor then
+        self.config.HeadColor = newConfig.HeadColor
+        if self.headLight then self.headLight.Color = newConfig.HeadColor end
+        if self.boostParticles then self.boostParticles.Color = ColorSequence.new(newConfig.HeadColor) end
+    end
+    if newConfig.BodyColors and typeof(newConfig.BodyColors) == "table" and #newConfig.BodyColors > 0 then
+        self.config.BodyColors = newConfig.BodyColors
+    end
+end
+
 function SkinnedSnake:startUpdateLoop()
     self.updateConnection = RunService.Heartbeat:Connect(function(deltaTime)
         if not self.isAlive then return end
@@ -464,4 +662,24 @@ function SkinnedSnake:destroy()
 end
 
 -- Module return
-return SkinnedSnake
+local OptimizedSnakeSystemV9 = {}
+
+function OptimizedSnakeSystemV9.init()
+    print("[OptimizedSnakeSystemV9] Initialized (Skinned Mesh, Bone-driven)")
+end
+
+function OptimizedSnakeSystemV9.createSnake(character, config)
+    return SkinnedSnake.new(character, config)
+end
+
+function OptimizedSnakeSystemV9.createSnakeFromSavedState(character, config, savedState)
+    local snake = SkinnedSnake.new(character, config)
+    if savedState and snake then
+        if savedState.length then
+            snake:updateLength(savedState.length)
+        end
+    end
+    return snake
+end
+
+return OptimizedSnakeSystemV9

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -668,19 +668,31 @@ function SkinnedSnake:setBoost(boosting)
 end
 
 function SkinnedSnake:updateColors()
+    if not self.headLight or not self.boostParticles then return end
+
     -- Cycle through body colors or apply rainbow mode
     if self.rainbowMode then
         local hue = (tick() * 0.5) % 1
         local color = Color3.fromHSV(hue, 1, 1)
         self.headLight.Color = color
         self.boostParticles.Color = ColorSequence.new(color)
-    else
-        -- Normal color cycling
-        self.currentColorIndex = (self.currentColorIndex % #self.config.BodyColors) + 1
-        local color = self.config.BodyColors[self.currentColorIndex]
-        self.headLight.Color = color
-        self.boostParticles.Color = ColorSequence.new(color)
+        return
     end
+
+    -- Normal color cycling with robust fallbacks
+    local colors = self.config and self.config.BodyColors or nil
+    local count = (type(colors) == "table") and #colors or 0
+    local color
+    if count > 0 then
+        self.currentColorIndex = (self.currentColorIndex % count) + 1
+        color = colors[self.currentColorIndex]
+    end
+    if typeof(color) ~= "Color3" then
+        color = self.config and self.config.HeadColor or Color3.fromRGB(76, 217, 100)
+    end
+
+    self.headLight.Color = color
+    self.boostParticles.Color = ColorSequence.new(color)
 end
 
 function SkinnedSnake:updateLength(newLength)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implemented spline-based bone animation with stable up-vectors to ensure a uniformly smooth snake body.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous bone animation caused "poking up/down" and uneven body segments. This update uses arc-length Catmull-Rom spline sampling for smooth path following, a stable up-vector to prevent roll, and per-bone transform smoothing to eliminate jitter, resulting in a natural and consistent snake appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-52c1c1ce-39e1-4c08-a4ff-fed0680cca65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52c1c1ce-39e1-4c08-a4ff-fed0680cca65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

