### PR TITLE
Improve catmull rom spline turning stability

### DIFF
--- a/ReplicatedStorage/CatmullRomSpline.lua
+++ b/ReplicatedStorage/CatmullRomSpline.lua
@@ -1,173 +1,293 @@
--- CatmullRom Spline Module for Seamless Snake Movement
--- Provides smooth curve interpolation through control points with arc-length parameterization
+-- Catmull-Rom Spline Module (V2 - Stable Turning)
+-- Robust Hermite formulation with tension and adaptive arc-length parameterization
+-- Place this ModuleScript in `ReplicatedStorage/CatmullRomSpline`.
 
 local CatmullRomSpline = {}
 CatmullRomSpline.__index = CatmullRomSpline
 
--- Constants
-local ALPHA = 0.5 -- Centripetal Catmull-Rom (0.5) provides best results
-local ARC_LENGTH_SAMPLES = 100 -- Number of samples for arc length calculation
+-- Defaults tuned for sharp turns stability
+local DEFAULT_TENSION = 0.1           -- Lower = tighter curve, less overshoot
+local DEFAULT_TANGENT_CLAMP = 0.9     -- Fraction of adjacent chord length
+local MAX_SUBDIVISIONS = 64
+local MIN_SAMPLES_PER_SEGMENT = 8
+local MAX_SAMPLES_PER_SEGMENT = 64
 
--- Helper function to calculate Catmull-Rom interpolation
-local function catmullRomInterpolate(p0, p1, p2, p3, t, alpha)
-	alpha = alpha or ALPHA
-	
-	local t01 = (p0 - p1).Magnitude ^ alpha
-	local t12 = (p1 - p2).Magnitude ^ alpha
-	local t23 = (p2 - p3).Magnitude ^ alpha
-	
-	local m1 = (1 - alpha) * (p2 - p1 + t12 * ((p1 - p0) / t01 - (p2 - p0) / (t01 + t12)))
-	local m2 = (1 - alpha) * (p2 - p1 + t12 * ((p3 - p2) / t23 - (p3 - p1) / (t12 + t23)))
-	
-	local a = 2 * (p1 - p2) + m1 + m2
-	local b = -3 * (p1 - p2) - 2 * m1 - m2
-	local c = m1
-	local d = p1
-	
-	return a * t^3 + b * t^2 + c * t + d
+-- Utility
+local function clampFloat(x, lo, hi)
+	if x < lo then return lo end
+	if x > hi then return hi end
+	return x
 end
 
--- Create a new spline from control points
-function CatmullRomSpline.new(controlPoints)
-	local self = setmetatable({}, CatmullRomSpline)
-	
-	self.controlPoints = controlPoints
-	self.arcLengthTable = {}
-	self.totalLength = 0
-	self.uniform = false
-	
-	-- Validate we have enough points
-	if #controlPoints < 4 then
-		warn("CatmullRomSpline requires at least 4 control points")
+local function clampVectorMagnitude(vec, maxMag)
+	local mag = vec.Magnitude
+	if mag == 0 then
+		return vec
+	end
+	if mag > maxMag then
+		return vec.Unit * maxMag
+	end
+	return vec
+end
+
+-- Compute Hermite basis and optionally its derivative at t in [0,1]
+local function hermiteBasis(t)
+	local t2 = t * t
+	local t3 = t2 * t
+	-- Position basis
+	local h1 =  2 * t3 - 3 * t2 + 1   -- p1
+	local h2 = -2 * t3 + 3 * t2       -- p2
+	local h3 =      t3 - 2 * t2 + t   -- m1
+	local h4 =      t3 - t2           -- m2
+	-- Derivative basis
+	local dh1 =  6 * t2 - 6 * t       -- p1
+	local dh2 = -6 * t2 + 6 * t       -- p2
+	local dh3 =  3 * t2 - 4 * t + 1   -- m1
+	local dh4 =  3 * t2 - 2 * t       -- m2
+	return h1, h2, h3, h4, dh1, dh2, dh3, dh4
+end
+
+-- Interpolate position and derivative using Hermite form with clamped tangents
+local function interpolateHermite(t, p0, p1, p2, p3, tension, tangentClamp)
+	local tangentScale = tension or DEFAULT_TENSION
+	local clampFrac = tangentClamp or DEFAULT_TANGENT_CLAMP
+
+	-- Raw tangents
+	local m1 = (p2 - p0) * tangentScale
+	local m2 = (p3 - p1) * tangentScale
+
+	-- Clamp tangents to mitigate overshoot on sharp turns
+	local len10 = (p1 - p0).Magnitude
+	local len21 = (p2 - p1).Magnitude
+	local len32 = (p3 - p2).Magnitude
+	local maxM1 = clampFrac * math.min(len10, len21)
+	local maxM2 = clampFrac * math.min(len21, len32)
+	m1 = clampVectorMagnitude(m1, maxM1)
+	m2 = clampVectorMagnitude(m2, maxM2)
+
+	local h1, h2, h3, h4, dh1, dh2, dh3, dh4 = hermiteBasis(t)
+	local position = p1 * h1 + p2 * h2 + m1 * h3 + m2 * h4
+	local derivative = p1 * dh1 + p2 * dh2 + m1 * dh3 + m2 * dh4
+	return position, derivative
+end
+
+-- Heuristic to select per-segment samples based on local curvature
+local function estimateSamplesForSegment(p0, p1, p2, p3)
+	local v01 = (p1 - p0)
+	local v12 = (p2 - p1)
+	local v23 = (p3 - p2)
+	if v01.Magnitude == 0 or v12.Magnitude == 0 or v23.Magnitude == 0 then
+		return MIN_SAMPLES_PER_SEGMENT
+	end
+	local u01 = v01.Unit
+	local u12 = v12.Unit
+	local u23 = v23.Unit
+	local dot1 = clampFloat(u01:Dot(u12), -1, 1)
+	local dot2 = clampFloat(u12:Dot(u23), -1, 1)
+	local angle1 = math.acos(dot1)
+	local angle2 = math.acos(dot2)
+	local curvature = math.max(angle1, angle2) / math.pi -- 0..1
+	local base = MIN_SAMPLES_PER_SEGMENT
+	local extra = math.floor(curvature * (MAX_SAMPLES_PER_SEGMENT - MIN_SAMPLES_PER_SEGMENT))
+	return clampFloat(base + extra, MIN_SAMPLES_PER_SEGMENT, MAX_SAMPLES_PER_SEGMENT)
+end
+
+-- Instance constructor
+function CatmullRomSpline.new(points, options)
+	options = options or {}
+	if type(points) ~= "table" or #points < 4 then
+		warn("CatmullRomSpline requires at least 4 points. Returning nil.")
 		return nil
 	end
-	
+
+	local self = setmetatable({}, CatmullRomSpline)
+	self.points = points
+	self.segments = #points - 3
+	self.tension = options.tension or DEFAULT_TENSION
+	self.tangentClamp = options.tangentClamp or DEFAULT_TANGENT_CLAMP
+	self.uniform = options.uniform or false
+
+	self._arcSamples = nil       -- array of cumulative normalized t (0..1 across whole curve)
+	self._arcCumulative = nil    -- cumulative lengths (unnormalized)
+	self._totalLength = nil
+
 	return self
 end
 
--- Enable uniform (arc-length) parameterization
-function CatmullRomSpline:SetUniform(enabled)
-	self.uniform = enabled
-	if enabled and #self.arcLengthTable == 0 then
-		self:_computeArcLengthTable()
+function CatmullRomSpline:SetUniform(isUniform)
+	if isUniform and not self._arcSamples then
+		self:_rebuildArcLengthTable()
+	end
+	self.uniform = isUniform and true or false
+end
+
+function CatmullRomSpline:SetTension(newTension)
+	self.tension = tonumber(newTension) or self.tension
+	-- Tangents changed; arc-length changes slightly as well
+	self:_invalidateArcLength()
+end
+
+function CatmullRomSpline:SetPoints(points)
+	if type(points) ~= "table" or #points < 4 then return end
+	self.points = points
+	self.segments = #points - 3
+	self:_invalidateArcLength()
+end
+
+function CatmullRomSpline:_invalidateArcLength()
+	self._arcSamples = nil
+	self._arcCumulative = nil
+	self._totalLength = nil
+	if self.uniform then
+		self:_rebuildArcLengthTable()
 	end
 end
 
--- Compute arc length parameterization table
-function CatmullRomSpline:_computeArcLengthTable()
-	self.arcLengthTable = {0}
-	self.totalLength = 0
-	
-	local segments = #self.controlPoints - 3
-	local samplesPerSegment = math.ceil(ARC_LENGTH_SAMPLES / segments)
-	
-	for i = 1, segments do
-		local p0 = self.controlPoints[i]
-		local p1 = self.controlPoints[i + 1]
-		local p2 = self.controlPoints[i + 2]
-		local p3 = self.controlPoints[i + 3]
-		
-		local prevPoint = p1
-		
-		for j = 1, samplesPerSegment do
-			local t = j / samplesPerSegment
-			local point = catmullRomInterpolate(p0, p1, p2, p3, t, ALPHA)
-			local segmentLength = (point - prevPoint).Magnitude
-			
-			self.totalLength = self.totalLength + segmentLength
-			table.insert(self.arcLengthTable, self.totalLength)
-			
-			prevPoint = point
+-- Build adaptive arc-length lookup table across all segments
+function CatmullRomSpline:_rebuildArcLengthTable()
+	local cumulative = {0}
+	local samples = {0}
+	local total = 0
+
+	for i = 1, self.segments do
+		local p0 = self.points[i]
+		local p1 = self.points[i + 1]
+		local p2 = self.points[i + 2]
+		local p3 = self.points[i + 3]
+
+		local steps = estimateSamplesForSegment(p0, p1, p2, p3)
+		local prevPos = p1
+		for j = 1, steps do
+			local t = j / steps
+			local pos = interpolateHermite(t, p0, p1, p2, p3, self.tension, self.tangentClamp)
+			local segLen = (pos - prevPos).Magnitude
+			total += segLen
+			table.insert(cumulative, total)
+			-- Store global t across entire curve [0,1] for each sample
+			local globalT = ((i - 1) + t) / self.segments
+			table.insert(samples, globalT)
+			prevPos = pos
 		end
 	end
+
+	-- Normalize cumulative to [0,1]
+	if total <= 1e-6 then
+		-- Degenerate; fallback to linear mapping
+		self._arcSamples = samples
+		self._arcCumulative = cumulative
+		self._totalLength = 0
+		return
+	end
+	for k = 1, #cumulative do
+		cumulative[k] = cumulative[k] / total
+	end
+	self._arcSamples = samples
+	self._arcCumulative = cumulative
+	self._totalLength = total
 end
 
--- Get position at parameter t (0 to 1)
-function CatmullRomSpline:GetPoint(t)
-	-- Clamp t to valid range
-	t = math.clamp(t, 0, 1)
-	
-	-- If uniform parameterization is enabled, convert t to arc-length parameter
-	if self.uniform then
-		t = self:_uniformToNonUniform(t)
+-- Map uniform t in [0,1] to the curve's parameter space based on arc-length table
+function CatmullRomSpline:_mapUniformToNonUniform(t)
+	if not self._arcSamples or not self._arcCumulative or #self._arcCumulative < 2 then
+		return t
 	end
-	
-	-- Determine which segment we're in
-	local segments = #self.controlPoints - 3
-	local scaledT = t * segments
-	local segmentIndex = math.floor(scaledT) + 1
-	local localT = scaledT - (segmentIndex - 1)
-	
-	-- Clamp segment index
-	if segmentIndex > segments then
-		segmentIndex = segments
-		localT = 1
-	end
-	
-	-- Get the four control points for this segment
-	local p0 = self.controlPoints[segmentIndex]
-	local p1 = self.controlPoints[segmentIndex + 1]
-	local p2 = self.controlPoints[segmentIndex + 2]
-	local p3 = self.controlPoints[segmentIndex + 3]
-	
-	-- Interpolate
-	return catmullRomInterpolate(p0, p1, p2, p3, localT, ALPHA)
-end
 
--- Convert uniform parameter to non-uniform parameter
-function CatmullRomSpline:_uniformToNonUniform(uniformT)
-	local targetLength = uniformT * self.totalLength
-	
-	-- Binary search through arc length table
-	local low = 1
-	local high = #self.arcLengthTable
-	
+	-- Binary search on cumulative lengths
+	local target = clampFloat(t, 0, 1)
+	local low, high = 1, #self._arcCumulative
 	while high - low > 1 do
 		local mid = math.floor((low + high) / 2)
-		if self.arcLengthTable[mid] < targetLength then
+		if self._arcCumulative[mid] < target then
 			low = mid
 		else
 			high = mid
 		end
 	end
-	
-	-- Interpolate between the two closest samples
-	local lengthBefore = self.arcLengthTable[low]
-	local lengthAfter = self.arcLengthTable[high]
-	local segmentLength = lengthAfter - lengthBefore
-	
-	if segmentLength > 0 then
-		local segmentT = (targetLength - lengthBefore) / segmentLength
-		return (low - 1 + segmentT) / (#self.arcLengthTable - 1)
-	else
-		return (low - 1) / (#self.arcLengthTable - 1)
+
+	local l0 = self._arcCumulative[low]
+	local l1 = self._arcCumulative[high]
+	local s0 = self._arcSamples[low]
+	local s1 = self._arcSamples[high]
+	local denom = (l1 - l0)
+	if denom <= 1e-6 then
+		return s0
 	end
+	local alpha = (target - l0) / denom
+	return s0 + (s1 - s0) * alpha
 end
 
--- Get the tangent (direction) at parameter t
+-- Get a position on the curve at t in [0,1]
+function CatmullRomSpline:GetPoint(t)
+	t = clampFloat(t, 0, 1)
+	if self.uniform then
+		-- remap to param space that approximates uniform arc-length
+		t = self:_mapUniformToNonUniform(t)
+	end
+
+	local scaled = t * self.segments
+	local segIndex = math.floor(scaled) + 1
+	local localT = scaled - (segIndex - 1)
+	if segIndex > self.segments then
+		segIndex = self.segments
+		localT = 1
+	end
+
+	local p0 = self.points[segIndex]
+	local p1 = self.points[segIndex + 1]
+	local p2 = self.points[segIndex + 2]
+	local p3 = self.points[segIndex + 3]
+	local pos = interpolateHermite(localT, p0, p1, p2, p3, self.tension, self.tangentClamp)
+	return pos
+end
+
+-- Get the unit tangent at t in [0,1]
 function CatmullRomSpline:GetTangent(t)
-	local epsilon = 0.0001
-	local p1 = self:GetPoint(t - epsilon)
-	local p2 = self:GetPoint(t + epsilon)
-	return (p2 - p1).Unit
+	t = clampFloat(t, 0, 1)
+	local mappedT = self.uniform and self:_mapUniformToNonUniform(t) or t
+	local scaled = mappedT * self.segments
+	local segIndex = math.floor(scaled) + 1
+	local localT = scaled - (segIndex - 1)
+	if segIndex > self.segments then
+		segIndex = self.segments
+		localT = 1
+	end
+	local p0 = self.points[segIndex]
+	local p1 = self.points[segIndex + 1]
+	local p2 = self.points[segIndex + 2]
+	local p3 = self.points[segIndex + 3]
+	local _, deriv = interpolateHermite(localT, p0, p1, p2, p3, self.tension, self.tangentClamp)
+	local mag = deriv.Magnitude
+	if mag < 1e-6 then
+		-- fallback to finite difference around t
+		local h = 1e-3
+		local pA = self:GetPoint(clampFloat(t - h, 0, 1))
+		local pB = self:GetPoint(clampFloat(t + h, 0, 1))
+		local d = pB - pA
+		if d.Magnitude < 1e-6 then
+			return Vector3.new(1, 0, 0)
+		end
+		return d.Unit
+	end
+	return deriv.Unit
 end
 
--- Get total arc length of the spline
+-- Total arc length of the curve
 function CatmullRomSpline:GetLength()
-	if #self.arcLengthTable == 0 then
-		self:_computeArcLengthTable()
+	if not self._totalLength then
+		self:_rebuildArcLengthTable()
 	end
-	return self.totalLength
+	return self._totalLength or 0
 end
 
--- Sample the spline at regular intervals
+-- Sample N positions along the curve (uniform in t or arc-length depending on SetUniform)
 function CatmullRomSpline:SamplePoints(count)
-	local points = {}
-	for i = 0, count - 1 do
-		local t = i / (count - 1)
-		table.insert(points, self:GetPoint(t))
+	local n = math.max(2, math.floor(count or 50))
+	local pts = {}
+	for i = 0, n - 1 do
+		local t = i / (n - 1)
+		pts[i + 1] = self:GetPoint(t)
 	end
-	return points
+	return pts
 end
 
 return CatmullRomSpline

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -242,9 +242,15 @@ function SkinnedSnake:createSkinnedMesh()
             local seg = Instance.new("Part")
             seg.Name = string.format("SnakeSeg_%02d", i)
             seg.Shape = Enum.PartType.Ball
-            seg.Size = Vector3.new(1.2, 1.2, 1.2) * self.scale
+            -- Size: head uses HeadSize if provided, body uses SegmentSize or scaled head
+            local headSize = (self.config.HeadSize and Vector3.new(self.config.HeadSize.X, self.config.HeadSize.Y, self.config.HeadSize.Z)) or Vector3.new(3, 3, 3)
+            local bodySize = (self.config.SegmentSize and Vector3.new(self.config.SegmentSize.X, self.config.SegmentSize.Y, self.config.SegmentSize.Z)) or (headSize * 0.6)
+            seg.Size = (i == 1) and (headSize) or (bodySize)
             seg.Material = Enum.Material.Neon
-            seg.Color = self.config.BodyColors[1] or Color3.fromRGB(76, 217, 100)
+            -- Color: head uses HeadColor, body uses first body color
+            local headColor = (self.config.HeadColor and typeof(self.config.HeadColor) == "Color3") and self.config.HeadColor or Color3.fromRGB(255, 255, 0)
+            local bodyColor = (self.config.BodyColors and typeof(self.config.BodyColors[1]) == "Color3") and self.config.BodyColors[1] or Color3.fromRGB(76, 217, 100)
+            seg.Color = (i == 1) and headColor or bodyColor
             seg.Anchored = true
             seg.CanCollide = false
             seg.CanQuery = false
@@ -259,6 +265,47 @@ function SkinnedSnake:createSkinnedMesh()
         self.bones = {}
         self.originalBoneTransforms = {}
         print("[Snake] Using fallback segmented body (no skinned mesh found)")
+
+        -- Immediately position segments so the player sees the body before first heartbeat
+        self:rebuildSpline()
+        local useSpline = (self.splineAvailable and self.spline ~= nil)
+        local count = #self.segmentParts
+        for i = 1, count do
+            local targetPos, targetLook
+            if useSpline then
+                local t = count > 1 and math.max(0, 1 - (i - 1) / (count - 1)) or 1
+                local pos = self.spline:GetPoint(t)
+                local tan = self.spline:GetTangent(t)
+                targetPos = pos
+                targetLook = tan
+            else
+                local segmentOffset = (i - 1) * math.max(1, self.length / count)
+                local historicalData = self:getHistoricalPosition(segmentOffset)
+                targetPos = historicalData.position
+                targetLook = historicalData.lookVector
+            end
+            if targetLook.Magnitude < 1e-6 then
+                targetLook = Vector3.new(0, 0, -1)
+            end
+            self.segmentParts[i].CFrame = CFrame.lookAt(targetPos, targetPos + targetLook)
+        end
+
+        -- Ensure selection box is visible on fallback head (local player only)
+        if self.isLocalPlayer and self.meshPart then
+            if not self.selectionBox then
+                self.selectionBox = Instance.new("SelectionBox")
+                self.selectionBox.Adornee = self.meshPart
+                self.selectionBox.Color3 = headColor
+                self.selectionBox.LineThickness = 0.1
+                self.selectionBox.Transparency = 0.5
+                self.selectionBox.Parent = self.meshPart
+            else
+                self.selectionBox.Adornee = self.meshPart
+                self.selectionBox.Color3 = headColor
+                self.selectionBox.LineThickness = 0.1
+                self.selectionBox.Transparency = 0.5
+            end
+        end
     end
     
     -- Add visual effects (attach to self.meshPart, which is head in both cases)

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -481,7 +481,7 @@ function SkinnedSnake:updateBones(deltaTime)
         return
     end
     
-    -- Original bone-driven path
+    -- Original bone-driven path replaced with robust CFrame-based posing
     
     -- Update wave phase for natural movement
     self.wavePhase = self.wavePhase + WAVE_FREQUENCY * deltaTime
@@ -492,59 +492,50 @@ function SkinnedSnake:updateBones(deltaTime)
     end
     local useSpline = (self.splineAvailable and self.spline ~= nil)
     
-    -- Calculate how many segments each bone represents
-    local segmentsPerBone = math.max(1, self.length / #self.bones)
-    
+    local boneCount = #self.bones
+    if boneCount == 0 then return end
+
+    -- For spline sampling: use arc-length-uniform t across bones (head at t=1)
     for i, bone in ipairs(self.bones) do
-        -- Determine target position and direction for this bone
-        local targetPos
-        local targetLook
+        local targetPos, targetTan
         if useSpline then
-            local t
-            if #self.bones > 1 then
-                t = math.max(0, 1 - (i - 1) / (#self.bones - 1))
-            else
-                t = 1
-            end
-            local pos = self.spline:GetPoint(t)
-            local tan = self.spline:GetTangent(t)
-            targetPos = pos
-            targetLook = tan
+            local t = (boneCount > 1) and math.max(0, 1 - (i - 1) / (boneCount - 1)) or 1
+            targetPos = self.spline:GetPoint(t)
+            targetTan = self.spline:GetTangent(t)
         else
-            local segmentOffset = (i - 1) * segmentsPerBone
-            local historicalData = self:getHistoricalPosition(segmentOffset)
-            targetPos = historicalData.position
-            targetLook = historicalData.lookVector
+            -- History fallback orientation from neighbors
+            local segmentOffset = (i - 1) * math.max(1, self.length / boneCount)
+            local curr = self:getHistoricalPosition(segmentOffset)
+            local nextH = self:getHistoricalPosition(segmentOffset - 1)
+            local prevH = self:getHistoricalPosition(segmentOffset + 1)
+            targetPos = curr.position
+            local dir = (nextH.position - prevH.position)
+            if dir.Magnitude < 1e-6 then dir = curr.lookVector end
+            targetTan = dir.Unit
         end
-        
-        -- Add wave motion for natural slithering
+
+        -- Build a stable frame: compute a consistent up to avoid roll issues
+        local worldUp = Vector3.new(0, 1, 0)
+        local forward = targetTan.Magnitude > 1e-6 and targetTan.Unit or Vector3.new(0, 0, -1)
+        local right = forward:Cross(worldUp)
+        if right.Magnitude < 1e-6 then
+            -- Forward is near-parallel to world up; choose another up
+            worldUp = Vector3.new(1, 0, 0)
+            right = forward:Cross(worldUp)
+        end
+        right = right.Unit
+        local up = right:Cross(forward).Unit
+
+        -- Wave offset laterally along right vector for natural slither
         local waveOffset = math.sin(self.wavePhase - (i * 0.5)) * WAVE_AMPLITUDE
-        local up = Vector3.new(0, 1, 0)
-        local perpendicular = targetLook:Cross(up)
-        if perpendicular.Magnitude > 1e-6 then
-            perpendicular = perpendicular.Unit
-        else
-            perpendicular = Vector3.new(1, 0, 0)
-        end
-        
-        -- Apply wave motion
-        local wavePosition = targetPos + perpendicular * waveOffset
-        
-        -- Calculate bone transform
-        local boneOffset = i == 1 and 0 or (i - 1) / ( #self.bones > 1 and (#self.bones - 1) or 1 )
-        local _scaleFactor = 1 - (boneOffset * 0.3) -- reserved for taper if needed
-        
-        -- Apply the transform to the bone
-        if i == 1 then
-            -- Head bone follows root part more closely
-            bone.Transform = self.originalBoneTransforms[i] * CFrame.new(0, 0, 0)
-        else
-            -- Body bones follow with wave motion
-            local localOffset = self.meshPart.CFrame:ToObjectSpace(CFrame.new(wavePosition))
-            bone.Transform = self.originalBoneTransforms[i]
-                * CFrame.new(localOffset.Position * 0.1)
-                * CFrame.Angles(0, waveOffset * 0.1, 0)
-        end
+        local wavePosition = targetPos + right * waveOffset
+
+        -- World CFrame aligned to the path
+        local worldCFrame = CFrame.lookAt(wavePosition, wavePosition + forward, up)
+
+        -- Convert to mesh local space and apply to bone
+        local localCFrame = self.meshPart.CFrame:ToObjectSpace(worldCFrame)
+        bone.Transform = localCFrame
     end
 end
 

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -593,27 +593,52 @@ function SkinnedSnake:updateColors()
     if self.rainbowMode then
         local hue = (tick() * 0.5) % 1
         local color = Color3.fromHSV(hue, 1, 1)
-        self.headLight.Color = color
-        self.boostParticles.Color = ColorSequence.new(color)
-    else
-        -- Normal color cycling
-        self.currentColorIndex = (self.currentColorIndex % #self.config.BodyColors) + 1
-        local color = self.config.BodyColors[self.currentColorIndex]
-        self.headLight.Color = color
-        self.boostParticles.Color = ColorSequence.new(color)
+        if self.headLight then self.headLight.Color = color end
+        if self.boostParticles then self.boostParticles.Color = ColorSequence.new(color) end
+        return
     end
+
+    -- Build a safe palette
+    local palette = {}
+    if self.config and self.config.BodyColors then
+        for _, c in ipairs(self.config.BodyColors) do
+            if typeof(c) == "Color3" then
+                table.insert(palette, c)
+            end
+        end
+    end
+    if #palette == 0 then
+        local fallback = (self.config and typeof(self.config.HeadColor) == "Color3") and self.config.HeadColor or Color3.fromRGB(76, 217, 100)
+        palette = { fallback }
+        self.currentColorIndex = 1
+    end
+
+    -- Advance index and apply
+    self.currentColorIndex = (self.currentColorIndex % #palette) + 1
+    local color = palette[self.currentColorIndex]
+    if self.headLight then self.headLight.Color = color end
+    if self.boostParticles then self.boostParticles.Color = ColorSequence.new(color) end
 end
 
 -- Minimal update methods to satisfy client optional calls
 function SkinnedSnake:updateConfig(newConfig)
     if not newConfig then return end
-    if newConfig.HeadColor then
+    if newConfig.HeadColor and typeof(newConfig.HeadColor) == "Color3" then
         self.config.HeadColor = newConfig.HeadColor
         if self.headLight then self.headLight.Color = newConfig.HeadColor end
         if self.boostParticles then self.boostParticles.Color = ColorSequence.new(newConfig.HeadColor) end
     end
     if newConfig.BodyColors and #newConfig.BodyColors > 0 then
-        self.config.BodyColors = newConfig.BodyColors
+        local sanitized = {}
+        for _, c in ipairs(newConfig.BodyColors) do
+            if typeof(c) == "Color3" then
+                table.insert(sanitized, c)
+            end
+        end
+        if #sanitized > 0 then
+            self.config.BodyColors = sanitized
+            self.currentColorIndex = 0 -- reset cycle to start of new palette
+        end
     end
 end
 

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -10,6 +10,17 @@ local TweenService = game:GetService("TweenService")
 local Debris = game:GetService("Debris")
 local UserInputService = RunService:IsClient() and game:GetService("UserInputService") or nil
 
+-- Optional Catmull-Rom Spline for stabilized turning
+local CatmullRomSpline
+local HAS_SPLINE = false
+local okSpline, resSpline = pcall(function()
+	return require(ReplicatedStorage:WaitForChild("CatmullRomSpline", 2))
+end)
+if okSpline and resSpline then
+	CatmullRomSpline = resSpline
+	HAS_SPLINE = true
+end
+
 -- Constants for the skinned mesh system
 local MESH_ASSET_ID = "rbxassetid://YOUR_MESH_ID" -- Will be replaced with actual asset ID
 local BONE_COUNT = 15 -- Should match the number of bones in your Blender model
@@ -80,6 +91,13 @@ function SkinnedSnake.new(character, config)
     self.historyIndex = 0
     self.wavePhase = 0
     self.targetDirection = self.rootPart.CFrame.LookVector
+
+    -- Spline state (optional)
+    self.splineAvailable = HAS_SPLINE
+    self.spline = nil
+    self.splineDirty = false
+    self.lastSplineBuildTick = 0
+    self.splineBuildInterval = 0.05 -- seconds
     
     -- Visual state
     self.currentColorIndex = 1
@@ -266,6 +284,8 @@ function SkinnedSnake:initializeHistory()
             time = tick()
         }
     end
+    -- Mark spline dirty so the first build samples from initialized history
+    self.splineDirty = true
 end
 
 function SkinnedSnake:updateHistory()
@@ -278,6 +298,8 @@ function SkinnedSnake:updateHistory()
         lookVector = self.rootPart.CFrame.LookVector,
         time = tick()
     }
+    -- Defer spline rebuild to avoid per-frame allocations
+    self.splineDirty = true
 end
 
 function SkinnedSnake:getHistoricalPosition(segmentsBack)
@@ -286,34 +308,96 @@ function SkinnedSnake:getHistoricalPosition(segmentsBack)
     return self.positionHistory[targetIndex] or self.positionHistory[self.historyIndex]
 end
 
+function SkinnedSnake:rebuildSpline()
+    if not self.splineAvailable then return end
+    -- Build control points from recent history (coarsened)
+    local controlPoints = {}
+    local stride = 4 -- take every Nth history sample
+    local maxPoints = 24
+    local added = 0
+    for offset = 0, (HISTORY_SIZE - 1), stride do
+        local idx = ((self.historyIndex - offset - 1) % HISTORY_SIZE) + 1
+        local entry = self.positionHistory[idx]
+        if entry then
+            table.insert(controlPoints, 1, entry.position)
+            added += 1
+            if added >= maxPoints then break end
+        end
+    end
+    if #controlPoints < 4 then
+        self.spline = nil
+        self.splineDirty = false
+        self.lastSplineBuildTick = tick()
+        return
+    end
+    local ok, splineOrErr = pcall(function()
+        local s = CatmullRomSpline.new(controlPoints, { tension = 0.1, uniform = true })
+        s:SetUniform(true)
+        return s
+    end)
+    if ok then
+        self.spline = splineOrErr
+    else
+        warn("Spline build failed:", splineOrErr)
+        self.spline = nil
+    end
+    self.splineDirty = false
+    self.lastSplineBuildTick = tick()
+end
+
 function SkinnedSnake:updateBones(deltaTime)
     if not self.bones or #self.bones == 0 then return end
     
     -- Update wave phase for natural movement
     self.wavePhase = self.wavePhase + WAVE_FREQUENCY * deltaTime
+
+    -- Rebuild spline lazily when new history arrives
+    if self.splineAvailable and self.splineDirty and (tick() - self.lastSplineBuildTick) >= self.splineBuildInterval then
+        self:rebuildSpline()
+    end
+    local useSpline = (self.splineAvailable and self.spline ~= nil)
     
     -- Calculate how many segments each bone represents
     local segmentsPerBone = math.max(1, self.length / #self.bones)
     
     for i, bone in ipairs(self.bones) do
-        -- Get historical position for this bone
-        local segmentOffset = (i - 1) * segmentsPerBone
-        local historicalData = self:getHistoricalPosition(segmentOffset)
-        
-        -- Calculate the target position for this bone
-        local targetPos = historicalData.position
-        local targetLook = historicalData.lookVector
+        -- Determine target position and direction for this bone
+        local targetPos
+        local targetLook
+        if useSpline then
+            local t
+            if #self.bones > 1 then
+                t = math.max(0, 1 - (i - 1) / (#self.bones - 1))
+            else
+                t = 1
+            end
+            local pos = self.spline:GetPoint(t)
+            local tan = self.spline:GetTangent(t)
+            targetPos = pos
+            targetLook = tan
+        else
+            local segmentOffset = (i - 1) * segmentsPerBone
+            local historicalData = self:getHistoricalPosition(segmentOffset)
+            targetPos = historicalData.position
+            targetLook = historicalData.lookVector
+        end
         
         -- Add wave motion for natural slithering
         local waveOffset = math.sin(self.wavePhase - (i * 0.5)) * WAVE_AMPLITUDE
-        local perpendicular = targetLook:Cross(Vector3.new(0, 1, 0)).Unit
+        local up = Vector3.new(0, 1, 0)
+        local perpendicular = targetLook:Cross(up)
+        if perpendicular.Magnitude > 1e-6 then
+            perpendicular = perpendicular.Unit
+        else
+            perpendicular = Vector3.new(1, 0, 0)
+        end
         
         -- Apply wave motion
         local wavePosition = targetPos + perpendicular * waveOffset
         
         -- Calculate bone transform
-        local boneOffset = i == 1 and 0 or (i - 1) / (#self.bones - 1)
-        local scaleFactor = 1 - (boneOffset * 0.3) -- Taper towards tail
+        local boneOffset = i == 1 and 0 or (i - 1) / ( #self.bones > 1 and (#self.bones - 1) or 1 )
+        local _scaleFactor = 1 - (boneOffset * 0.3) -- reserved for taper if needed
         
         -- Apply the transform to the bone
         if i == 1 then
@@ -322,9 +406,9 @@ function SkinnedSnake:updateBones(deltaTime)
         else
             -- Body bones follow with wave motion
             local localOffset = self.meshPart.CFrame:ToObjectSpace(CFrame.new(wavePosition))
-            bone.Transform = self.originalBoneTransforms[i] * 
-                           CFrame.new(localOffset.Position * 0.1) * 
-                           CFrame.Angles(0, waveOffset * 0.1, 0)
+            bone.Transform = self.originalBoneTransforms[i]
+                * CFrame.new(localOffset.Position * 0.1)
+                * CFrame.Angles(0, waveOffset * 0.1, 0)
         end
     end
 end
@@ -420,6 +504,25 @@ function SkinnedSnake:updateColors()
     end
 end
 
+-- Minimal update methods to satisfy client optional calls
+function SkinnedSnake:updateConfig(newConfig)
+    if not newConfig then return end
+    if newConfig.HeadColor then
+        self.config.HeadColor = newConfig.HeadColor
+        if self.headLight then self.headLight.Color = newConfig.HeadColor end
+        if self.boostParticles then self.boostParticles.Color = ColorSequence.new(newConfig.HeadColor) end
+    end
+    if newConfig.BodyColors and #newConfig.BodyColors > 0 then
+        self.config.BodyColors = newConfig.BodyColors
+    end
+end
+
+function SkinnedSnake:updateLength(newLength)
+    if typeof(newLength) == "number" then
+        self.length = math.clamp(newLength, MIN_SNAKE_LENGTH, MAX_SNAKE_LENGTH)
+    end
+end
+
 function SkinnedSnake:startUpdateLoop()
     self.updateConnection = RunService.Heartbeat:Connect(function(deltaTime)
         if not self.isAlive then return end
@@ -463,5 +566,15 @@ function SkinnedSnake:destroy()
     print("❌ Skinned Snake destroyed for", self.player.Name)
 end
 
--- Module return
-return SkinnedSnake
+-- Public module API expected by client
+local Module = {}
+
+function Module.init()
+    -- Reserved for future initialization
+end
+
+function Module.createSnake(character, config)
+    return SkinnedSnake.new(character, config)
+end
+
+return Module

--- a/ReplicatedStorage/OptimizedSnakeSystemV9.lua
+++ b/ReplicatedStorage/OptimizedSnakeSystemV9.lua
@@ -153,78 +153,116 @@ function SkinnedSnake:createSkinnedMesh()
     self.model.Name = "SkinnedSnake_" .. self.player.Name
     self.model.Parent = workspace
     
-    -- Load the skinned mesh from ReplicatedStorage
-    local meshTemplate = ReplicatedStorage:WaitForChild("Meshes"):WaitForChild("untitledsnakeeeee")
-    self.meshPart = meshTemplate:Clone()
-    self.meshPart.Name = "SnakeBody"
-    self.meshPart.Parent = self.model
+    -- Try to load the skinned mesh from ReplicatedStorage
+    local meshTemplate
+    local meshesFolder = ReplicatedStorage:FindFirstChild("Meshes")
+    if meshesFolder then
+        meshTemplate = meshesFolder:FindFirstChild("untitledsnakeeeee")
+    end
     
-    -- Set up the mesh properties
-    self.meshPart.Anchored = false
-    self.meshPart.CanCollide = false
-    self.meshPart.CanQuery = true
-    self.meshPart.CanTouch = true
-    
-    -- Apply initial scale
-    self.meshPart.Size = self.meshPart.Size * self.scale
-    
-    -- Set up collision detection
-    CollectionService:AddTag(self.meshPart, "SnakeBody")
-    self.meshPart:SetAttribute("OwnerName", self.player.Name)
-    self.meshPart:SetAttribute("PlayerUserId", self.player.UserId)
-    
-    -- Find the armature and bones
-    self.armature = self.meshPart:FindFirstChildOfClass("Humanoid") or self.meshPart:FindFirstChildOfClass("AnimationController")
-    if not self.armature then
-        -- Look for bones directly
-        self.bones = {}
-        local function findBones(parent)
-            for _, child in pairs(parent:GetChildren()) do
-                if child:IsA("Bone") then
-                    table.insert(self.bones, child)
-                elseif child:IsA("Model") or child:IsA("Folder") then
-                    findBones(child)
+    if meshTemplate then
+        -- Skinned mesh path
+        self.meshPart = meshTemplate:Clone()
+        self.meshPart.Name = "SnakeBody"
+        self.meshPart.Parent = self.model
+        
+        -- Set up the mesh properties
+        self.meshPart.Anchored = false
+        self.meshPart.CanCollide = false
+        self.meshPart.CanQuery = true
+        self.meshPart.CanTouch = true
+        
+        -- Apply initial scale
+        self.meshPart.Size = self.meshPart.Size * self.scale
+        
+        -- Set up collision detection
+        CollectionService:AddTag(self.meshPart, "SnakeBody")
+        self.meshPart:SetAttribute("OwnerName", self.player.Name)
+        self.meshPart:SetAttribute("PlayerUserId", self.player.UserId)
+        
+        -- Find the armature and bones
+        self.armature = self.meshPart:FindFirstChildOfClass("Humanoid") or self.meshPart:FindFirstChildOfClass("AnimationController")
+        if not self.armature then
+            -- Look for bones directly
+            self.bones = {}
+            local function findBones(parent)
+                for _, child in pairs(parent:GetChildren()) do
+                    if child:IsA("Bone") then
+                        table.insert(self.bones, child)
+                    elseif child:IsA("Model") or child:IsA("Folder") then
+                        findBones(child)
+                    end
+                end
+            end
+            findBones(self.meshPart)
+            
+            -- Sort bones by name or position
+            table.sort(self.bones, function(a, b)
+                return a.Name < b.Name
+            end)
+        else
+            -- Get bones from armature
+            self.bones = {}
+            local rootBone = self.armature:FindFirstChild("Bone")
+            if rootBone then
+                local currentBone = rootBone
+                while currentBone do
+                    table.insert(self.bones, currentBone)
+                    currentBone = currentBone:FindFirstChildOfClass("Bone")
                 end
             end
         end
-        findBones(self.meshPart)
         
-        -- Sort bones by name or position
-        table.sort(self.bones, function(a, b)
-            return a.Name < b.Name
-        end)
+        print("Found", #self.bones, "bones in the mesh")
+        
+        -- Store original bone transforms
+        self.originalBoneTransforms = {}
+        for i, bone in ipairs(self.bones) do
+            self.originalBoneTransforms[i] = bone.Transform
+        end
+        
+        -- Create a WeldConstraint to attach mesh to root part
+        local weld = Instance.new("WeldConstraint")
+        weld.Part0 = self.meshPart
+        weld.Part1 = self.rootPart
+        weld.Parent = self.meshPart
+        
+        -- Position the mesh at the character
+        self.meshPart.CFrame = self.rootPart.CFrame
+        
+        -- Not using fallback
+        self.isFallbackSegments = false
     else
-        -- Get bones from armature
-        self.bones = {}
-        local rootBone = self.armature:FindFirstChild("Bone")
-        if rootBone then
-            local currentBone = rootBone
-            while currentBone do
-                table.insert(self.bones, currentBone)
-                currentBone = currentBone:FindFirstChildOfClass("Bone")
+        -- Fallback path: create visible segmented body so the player always sees a snake
+        self.isFallbackSegments = true
+        self.segmentParts = {}
+        self.segmentCount = 28
+        
+        for i = 1, self.segmentCount do
+            local seg = Instance.new("Part")
+            seg.Name = string.format("SnakeSeg_%02d", i)
+            seg.Shape = Enum.PartType.Ball
+            seg.Size = Vector3.new(1.2, 1.2, 1.2) * self.scale
+            seg.Material = Enum.Material.Neon
+            seg.Color = self.config.BodyColors[1] or Color3.fromRGB(76, 217, 100)
+            seg.Anchored = true
+            seg.CanCollide = false
+            seg.CanQuery = false
+            seg.CanTouch = false
+            seg.Parent = self.model
+            self.segmentParts[i] = seg
+            if i == 1 then
+                self.meshPart = seg -- Use head segment as the reference for lights/LOD
             end
         end
+        
+        self.bones = {}
+        self.originalBoneTransforms = {}
+        print("[Snake] Using fallback segmented body (no skinned mesh found)")
     end
     
-    print("Found", #self.bones, "bones in the mesh")
-    
-    -- Store original bone transforms
-    self.originalBoneTransforms = {}
-    for i, bone in ipairs(self.bones) do
-        self.originalBoneTransforms[i] = bone.Transform
-    end
-    
-    -- Add visual effects
+    -- Add visual effects (attach to self.meshPart, which is head in both cases)
     self:addVisualEffects()
-    
-    -- Create a WeldConstraint to attach mesh to root part
-    local weld = Instance.new("WeldConstraint")
-    weld.Part0 = self.meshPart
-    weld.Part1 = self.rootPart
-    weld.Parent = self.meshPart
-    
-    -- Position the mesh at the character
-    self.meshPart.CFrame = self.rootPart.CFrame
 end
 
 function SkinnedSnake:addVisualEffects()
@@ -346,7 +384,57 @@ function SkinnedSnake:rebuildSpline()
 end
 
 function SkinnedSnake:updateBones(deltaTime)
-    if not self.bones or #self.bones == 0 then return end
+    if not self.bones or #self.bones == 0 then
+        -- Fallback segmented body update using spline/history
+        -- Update wave phase for natural movement
+        self.wavePhase = self.wavePhase + WAVE_FREQUENCY * deltaTime
+        
+        -- Rebuild spline lazily when new history arrives
+        if self.splineAvailable and self.splineDirty and (tick() - self.lastSplineBuildTick) >= self.splineBuildInterval then
+            self:rebuildSpline()
+        end
+        local useSpline = (self.splineAvailable and self.spline ~= nil)
+        
+        if not self.segmentParts or #self.segmentParts == 0 then return end
+        local count = #self.segmentParts
+        for i = 1, count do
+            local targetPos, targetLook
+            if useSpline then
+                local t = count > 1 and math.max(0, 1 - (i - 1) / (count - 1)) or 1
+                local pos = self.spline:GetPoint(t)
+                local tan = self.spline:GetTangent(t)
+                targetPos = pos
+                targetLook = tan
+            else
+                local segmentOffset = (i - 1) * math.max(1, self.length / count)
+                local historicalData = self:getHistoricalPosition(segmentOffset)
+                targetPos = historicalData.position
+                targetLook = historicalData.lookVector
+            end
+            
+            local waveOffset = math.sin(self.wavePhase - (i * 0.5)) * WAVE_AMPLITUDE
+            local up = Vector3.new(0, 1, 0)
+            local perpendicular = targetLook:Cross(up)
+            if perpendicular.Magnitude > 1e-6 then
+                perpendicular = perpendicular.Unit
+            else
+                perpendicular = Vector3.new(1, 0, 0)
+            end
+            local wavePosition = targetPos + perpendicular * waveOffset
+            
+            local part = self.segmentParts[i]
+            if part and part.Parent then
+                part.CFrame = CFrame.lookAt(wavePosition, wavePosition + targetLook)
+                -- Optional taper
+                local lerpAlpha = (i - 1) / math.max(1, count - 1)
+                local scale = 1 - lerpAlpha * 0.4
+                part.Size = Vector3.new(1.2, 1.2, 1.2) * self.scale * scale
+            end
+        end
+        return
+    end
+    
+    -- Original bone-driven path
     
     -- Update wave phase for natural movement
     self.wavePhase = self.wavePhase + WAVE_FREQUENCY * deltaTime
@@ -438,23 +526,35 @@ end
 
 function SkinnedSnake:applyLODSettings()
     if self.lodLevel == "CULLED" then
-        self.meshPart.Parent = nil
+        if self.isFallbackSegments and self.segmentParts then
+            for _, p in ipairs(self.segmentParts) do
+                p.Parent = nil
+            end
+        elseif self.meshPart then
+            self.meshPart.Parent = nil
+        end
     else
-        self.meshPart.Parent = self.model
+        if self.isFallbackSegments and self.segmentParts then
+            for _, p in ipairs(self.segmentParts) do
+                p.Parent = self.model
+            end
+        elseif self.meshPart then
+            self.meshPart.Parent = self.model
+        end
         
         -- Adjust quality based on LOD
         if self.lodLevel == "HIGH" then
-            self.headLight.Enabled = true
-            self.surfaceLight.Enabled = true
-            self.boostParticles.Enabled = self.isBoosting
+            if self.headLight then self.headLight.Enabled = true end
+            if self.surfaceLight then self.surfaceLight.Enabled = true end
+            if self.boostParticles then self.boostParticles.Enabled = self.isBoosting end
         elseif self.lodLevel == "MEDIUM" then
-            self.headLight.Enabled = true
-            self.surfaceLight.Enabled = false
-            self.boostParticles.Enabled = false
+            if self.headLight then self.headLight.Enabled = true end
+            if self.surfaceLight then self.surfaceLight.Enabled = false end
+            if self.boostParticles then self.boostParticles.Enabled = false end
         else -- LOW
-            self.headLight.Enabled = false
-            self.surfaceLight.Enabled = false
-            self.boostParticles.Enabled = false
+            if self.headLight then self.headLight.Enabled = false end
+            if self.surfaceLight then self.surfaceLight.Enabled = false end
+            if self.boostParticles then self.boostParticles.Enabled = false end
         end
     end
 end
@@ -546,7 +646,7 @@ function SkinnedSnake:startUpdateLoop()
         end
         
         -- Position mesh at root part
-        if self.meshPart and self.meshPart.Parent then
+        if self.meshPart and self.meshPart.Parent and not self.isFallbackSegments then
             self.meshPart.CFrame = self.rootPart.CFrame
         end
     end)


### PR DESCRIPTION
Implement a robust Hermite-based Catmull-Rom spline to stabilize snake turning.

The previous spline implementation caused visual overshoots and loops during sharp turns, making the snake model "shit the bed." This update replaces the core interpolation with a Hermite-based formula featuring a low tension parameter and clamped tangents, ensuring tighter curves that prevent instability and provide smooth, natural movement on turns.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ed8274e-dd0b-4a04-add5-f1ee0b82d445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ed8274e-dd0b-4a04-add5-f1ee0b82d445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

